### PR TITLE
Lowercase all repository letters with ${value,,}' this is supported in Bash 4.x

### DIFF
--- a/.github/actions/build-bareos-app/entrypoint.sh
+++ b/.github/actions/build-bareos-app/entrypoint.sh
@@ -29,15 +29,15 @@ while read app version arch app_path ; do
     --build-arg VERSION=$(echo "$version" |cut -d'-' -f1) \
     --build-arg VCS_REF=$(git rev-parse --short HEAD) \
     --build-arg BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
-    --build-arg NAME="${GITHUB_REPOSITORY}-${app}" \
+    --build-arg NAME="${GITHUB_REPOSITORY,,}-${app}" \
     --output 'type=docker,push=false' \
-    --tag "${GITHUB_REPOSITORY}-${app}:${tag}" \
+    --tag "${GITHUB_REPOSITORY,,}-${app}:${tag}" \
     "${app_path}"
 
   # Save image to tar file
   docker save \
     --output "${workdir}/bareos-${app}-${tag}.tar" \
-    "${GITHUB_REPOSITORY}-${app}:${tag}"
+    "${GITHUB_REPOSITORY,,}-${app}:${tag}"
 done < "${workdir}/app_build.txt"
 
 chmod 755 "${workdir}"/bareos-*.tar

--- a/.github/actions/push-bareos-app/entrypoint.sh
+++ b/.github/actions/push-bareos-app/entrypoint.sh
@@ -20,25 +20,25 @@ while read app version arch app_path ; do
   re='^[0-9]+-alpine.*$'
   if [[ $version =~ $re ]] ; then
     build_tag="${version}-${arch}"
-    rm_tag="$rm_tag ${GITHUB_REPOSITORY}-${app}:${build_tag}"
+    rm_tag="$rm_tag ${GITHUB_REPOSITORY,,}-${app}:${build_tag}"
   fi
   # Push build_tag
-  docker push "${GITHUB_REPOSITORY}-${app}:${build_tag}"
+  docker push "${GITHUB_REPOSITORY,,}-${app}:${build_tag}"
 done < "${workdir}/app_build.txt"
 
 while read build_app s_tag t_tag ; do
   # Add and push tag for Ubuntu 
   if [[ $s_tag =~ ^[0-9]+-ubuntu.*$ ]]; then
-    docker tag "${GITHUB_REPOSITORY}-${build_app}:${s_tag}" \
-      "${GITHUB_REPOSITORY}-${build_app}:${t_tag}"
-    docker push "${GITHUB_REPOSITORY}-${build_app}:${t_tag}"
+    docker tag "${GITHUB_REPOSITORY,,}-${build_app}:${s_tag}" \
+      "${GITHUB_REPOSITORY,,}-${build_app}:${t_tag}"
+    docker push "${GITHUB_REPOSITORY,,}-${build_app}:${t_tag}"
   fi
   # Create and push manifest for Alpuine (arm64 + amd64)
   if [[ $s_tag =~ ^[0-9]+-alpine.*$ ]]; then
-    docker manifest create "${GITHUB_REPOSITORY}-${build_app}:${t_tag}" \
-      "${GITHUB_REPOSITORY}-${build_app}:${s_tag}-amd64" \
-      "${GITHUB_REPOSITORY}-${build_app}:${s_tag}-arm64"
-    docker manifest push "${GITHUB_REPOSITORY}-${build_app}:${t_tag}"
+    docker manifest create "${GITHUB_REPOSITORY,,}-${build_app}:${t_tag}" \
+      "${GITHUB_REPOSITORY,,}-${build_app}:${s_tag}-amd64" \
+      "${GITHUB_REPOSITORY,,}-${build_app}:${s_tag}-arm64"
+    docker manifest push "${GITHUB_REPOSITORY,,}-${build_app}:${t_tag}"
   fi
 done < "${workdir}/tag_build.txt"
 


### PR DESCRIPTION
Lowercase all repository letters with ${value,,}' this is supported in Bash 4.x
ex: my username is Dark-Vex and this will fail to run docker build because wants all the letters lowercase