### PR TITLE
fix(ci): update container name for Docker Compose V2 naming convention

### DIFF
--- a/.github/workflows/run-compose.yml
+++ b/.github/workflows/run-compose.yml
@@ -47,4 +47,4 @@ jobs:
       - name: Wait 60s then run Bareos console
         run: |
           sleep 60
-          docker exec bareos_bareos-dir_1 bconsole
+          docker exec bareos-bareos-dir-1 bconsole


### PR DESCRIPTION
Docker Compose V2 uses hyphens instead of underscores in container names. The bconsole exec step was referencing the old V1 name (bareos_bareos-dir_1) instead of the current V2 name (bareos-bareos-dir-1).