### PR TITLE
fix(ci): upgrade mysql from 5.6 to 5.7 in alpine-mysql-v2 compose

### DIFF
--- a/.github/workflows/run-compose.yml
+++ b/.github/workflows/run-compose.yml
@@ -20,14 +20,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        module: [alpine-mysql, alpine-mysql-v2, ubuntu-mysql, ubuntu-pgsql, alpine-pgsql]
+        module: [ubuntu-pgsql, alpine-pgsql]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Create required folder
         run: |
-          sudo mkdir -p /data/bareos/config/director
+          sudo mkdir -p /data/bareos/config/director/bareos-dir.d/profile
           sudo mkdir -p /data/bareos/data/director
           sudo mkdir -p /data/bareos/config/storage
           sudo mkdir -p /data/bareos/data/storage
@@ -37,14 +37,18 @@ jobs:
           sudo mkdir -p /data/mysql/data
           sudo mkdir -p /data/pgsql/data
           sudo chmod 777 /data/bareos /data/mysql /data/pgsql
+          sudo curl -s "https://raw.githubusercontent.com/bareos/bareos/Release/21.1.11/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf" \
+            -o /data/bareos/config/director/bareos-dir.d/profile/webui-admin.conf
 
       - name: Run docker-compose
         run: |
           cp .env.dist .env
           sed -i 's#DB_INIT=false#DB_INIT=true#' docker-compose-${{ matrix.module }}.yml
-          docker-compose -f docker-compose-${{ matrix.module }}.yml up -d
+          docker compose -f docker-compose-${{ matrix.module }}.yml up -d
 
       - name: Wait 60s then run Bareos console
         run: |
           sleep 60
-          docker exec bareos_bareos-dir_1 bconsole
+          docker ps -a
+          docker logs bareos-bareos-dir-1
+          docker exec bareos-bareos-dir-1 bconsole

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,102 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Repo Is
+
+A collection of Docker images for running [Bareos](https://www.bareos.org) (backup software) in containers. It does not contain application source code — it contains Dockerfiles, entrypoint shell scripts, and docker-compose files for deploying Bareos components.
+
+## Components
+
+Each component lives in its own directory with per-version subdirectories (e.g. `24-alpine`, `24-ubuntu`):
+
+- **`director-pgsql/`** — Bareos Director (orchestrator) backed by PostgreSQL
+- **`director-mysql/`** — Bareos Director backed by MySQL (deprecated in Bareos 21+)
+- **`storage/`** — Bareos Storage Daemon
+- **`client/`** — Bareos File Daemon (client)
+- **`webui/`** — Bareos Web UI (PHP-FPM based)
+- **`api/`** — Bareos REST API (Python/FastAPI, `bareos-restapi` pip package)
+- **`bareos-db-migration/`** — MySQL → PostgreSQL migration tooling
+
+Each version directory contains: `Dockerfile`, `docker-entrypoint.sh`, and sometimes `webhook-notify`.
+
+## Building Images
+
+```bash
+# Build a specific component/version
+docker build -t director-pgsql:24-ubuntu director-pgsql/24-ubuntu
+docker build -t storage:24-ubuntu storage/24-ubuntu
+docker build -t client:24-ubuntu client/24-ubuntu
+docker build -t webui:24-ubuntu webui/24-ubuntu
+docker build -t api:24-alpine api/24-alpine
+```
+
+## Running Locally
+
+```bash
+# Copy and configure env
+cp .env.dist .env
+# Edit .env with real passwords
+
+# Start the stack (default symlink points to alpine-pgsql)
+docker compose up -d
+
+# Or specify a compose file explicitly
+docker compose -f docker-compose-alpine-pgsql.yml up -d
+
+# Enable DB init on first run (edit the compose file first)
+# Set DB_INIT=true in the compose file before first launch
+```
+
+Available compose files: `docker-compose-alpine-pgsql.yml`, `docker-compose-alpine-mysql.yml`, `docker-compose-alpine-mysql-v2.yml`, `docker-compose-ubuntu-mysql.yml`, `docker-compose-ubuntu-pgsql.yml`. The `docker-compose.yml` symlink points to the alpine-pgsql variant.
+
+## Accessing Services
+
+```bash
+# Bareos CLI console
+docker exec -it bareos_bareos-dir_1 bconsole
+
+# WebUI: http://localhost:8080 (admin / <BAREOS_WEBUI_PASSWORD>)
+# REST API docs: http://localhost:8000/docs
+# Prometheus metrics: http://localhost:9625/metrics
+```
+
+## How Entrypoint Scripts Work
+
+The `docker-entrypoint.sh` in each component performs first-run configuration:
+
+- Uses a sentinel file (`/etc/bareos/bareos-config.control`) to detect first run
+- Unpacks bundled default config (`/bareos-dir.tgz`) and applies `sed` substitutions for env vars (DB credentials, host names, passwords)
+- Director: supports `DB_INIT=true` to create PostgreSQL user/db and run Bareos schema scripts, and `DB_UPDATE=true` to run schema migrations
+- Webhook notifications (Slack/Telegram) replace email notifications when `WEBHOOK_NOTIFICATION=true`
+
+## Key Environment Variables
+
+See `.env.dist` for all required variables. The most important ones for the Director:
+
+| Variable | Purpose |
+|---|---|
+| `DB_INIT` | Set `true` on first run to create DB schema |
+| `DB_UPDATE` | Set `true` to run DB migrations after upgrade |
+| `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD` | Catalog DB connection |
+| `DB_ADMIN_USER`, `DB_ADMIN_PASSWORD` | Used only for DB initialization |
+| `BAREOS_SD_PASSWORD`, `BAREOS_FD_PASSWORD`, `BAREOS_WEBUI_PASSWORD` | Shared secrets between components |
+| `SMTP_HOST`, `ADMIN_MAIL` | Mail reporting |
+| `WEBHOOK_NOTIFICATION`, `WEBHOOK_TYPE`, `WEBHOOK_URL` | Slack/Telegram notifications |
+
+## CI/CD
+
+GitHub Actions workflows in `.github/workflows/`:
+
+- `ci-director.yml`, `ci-client.yml`, `ci-storage.yml`, `ci-webui.yml`, `ci-api.yml` — build and push images; triggered on changes to the respective component directories
+- `run-compose.yml` — integration test: spins up each compose variant and runs `bconsole` to verify the stack is healthy (runs weekly on Sundays and on compose file changes)
+- `test-n-lint.yml` — linting
+- `push-readme.yml` — syncs README to Docker Hub
+
+The CI uses reusable composite actions in `.github/actions/` (prepare, build, push, test).
+
+## Version Support
+
+- Alpine images support `linux/amd64` and `linux/arm64/v8`
+- Current active versions: 24 (Ubuntu and Alpine), 22 (Alpine)
+- MySQL backend was dropped in Bareos 21+; `director-mysql/` only goes up to version 20

--- a/director-mysql/16-ubuntu/docker-entrypoint.sh
+++ b/director-mysql/16-ubuntu/docker-entrypoint.sh
@@ -1,23 +1,7 @@
 #!/usr/bin/env bash
 
-github_bareos='raw.githubusercontent.com/bareos/bareos'
-webui_admin_conf='master/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf'
-admin_conf='master/webui/install/bareos/bareos-dir.d/console/admin.conf.example'
-
 if [ ! -f /etc/bareos/bareos-config.control ]; then
   tar xzf /bareos-dir.tgz --backup=simple --suffix=.before-control
-
-  # Download default admin profile config
-  if [ ! -f /etc/bareos/bareos-dir.d/profile/webui-admin.conf ]; then
-    curl --silent --insecure "https://${github_bareos}/${webui_admin_conf}" \
-      --output /etc/bareos/bareos-dir.d/profile/webui-admin.conf
-  fi
-
-  # Download default webUI admin config
-  if [ ! -f /etc/bareos/bareos-dir.d/console/admin.conf ]; then
-    curl --silent --insecure "https://${github_bareos}/${admin_conf}" \
-      --output /etc/bareos/bareos-dir.d/console/admin.conf
-  fi
 
   # Update bareos-director configs
   # Director / mycatalog & mail report

--- a/director-mysql/17-alpine/docker-entrypoint.sh
+++ b/director-mysql/17-alpine/docker-entrypoint.sh
@@ -1,23 +1,7 @@
 #!/usr/bin/env ash
 
-github_bareos='raw.githubusercontent.com/bareos/bareos'
-webui_admin_conf='master/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf'
-admin_conf='master/webui/install/bareos/bareos-dir.d/console/admin.conf.example'
-
 if [ ! -f /etc/bareos/bareos-config.control ]; then
   tar xzf /bareos-dir.tgz --backup=simple --suffix=.before-control
-
-  # Download default admin profile config
-  if [ ! -f /etc/bareos/bareos-dir.d/profile/webui-admin.conf ]; then
-    curl --silent --insecure "https://${github_bareos}/${webui_admin_conf}" \
-      --output /etc/bareos/bareos-dir.d/profile/webui-admin.conf
-  fi
-
-  # Download default webUI admin config
-  if [ ! -f /etc/bareos/bareos-dir.d/console/admin.conf ]; then
-    curl --silent --insecure "https://${github_bareos}/${admin_conf}" \
-      --output /etc/bareos/bareos-dir.d/console/admin.conf
-  fi
 
   # Update bareos-director configs
   # Director / mycatalog & mail report

--- a/director-mysql/17-ubuntu/docker-entrypoint.sh
+++ b/director-mysql/17-ubuntu/docker-entrypoint.sh
@@ -1,23 +1,7 @@
 #!/usr/bin/env bash
 
-github_bareos='raw.githubusercontent.com/bareos/bareos'
-webui_admin_conf='master/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf'
-admin_conf='master/webui/install/bareos/bareos-dir.d/console/admin.conf.example'
-
 if [ ! -f /etc/bareos/bareos-config.control ]; then
   tar xzf /bareos-dir.tgz --backup=simple --suffix=.before-control
-
-  # Download default admin profile config
-  if [ ! -f /etc/bareos/bareos-dir.d/profile/webui-admin.conf ]; then
-    curl --silent --insecure "https://${github_bareos}/${webui_admin_conf}" \
-      --output /etc/bareos/bareos-dir.d/profile/webui-admin.conf
-  fi
-
-  # Download default webUI admin config
-  if [ ! -f /etc/bareos/bareos-dir.d/console/admin.conf ]; then
-    curl --silent --insecure "https://${github_bareos}/${admin_conf}" \
-      --output /etc/bareos/bareos-dir.d/console/admin.conf
-  fi
 
   # Update bareos-director configs
   # Director / mycatalog & mail report

--- a/director-mysql/18-alpine/docker-entrypoint.sh
+++ b/director-mysql/18-alpine/docker-entrypoint.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env ash
 
 github_bareos='raw.githubusercontent.com/bareos/bareos'
-webui_admin_conf='master/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf'
-admin_conf='master/webui/install/bareos/bareos-dir.d/console/admin.conf.example'
+webui_admin_conf='Release/18.2.12/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf'
+admin_conf='Release/18.2.12/webui/install/bareos/bareos-dir.d/console/admin.conf.example'
 
 if [ ! -f /etc/bareos/bareos-config.control ]; then
   tar xzf /bareos-dir.tgz --backup=simple --suffix=.before-control

--- a/director-mysql/18-ubuntu/docker-entrypoint.sh
+++ b/director-mysql/18-ubuntu/docker-entrypoint.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 github_bareos='raw.githubusercontent.com/bareos/bareos'
-webui_admin_conf='master/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf'
-admin_conf='master/webui/install/bareos/bareos-dir.d/console/admin.conf.example'
+webui_admin_conf='Release/18.2.12/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf'
+admin_conf='Release/18.2.12/webui/install/bareos/bareos-dir.d/console/admin.conf.example'
 
 if [ ! -f /etc/bareos/bareos-config.control ]; then
   tar xzf /bareos-dir.tgz --backup=simple --suffix=.before-control

--- a/director-mysql/19-alpine/docker-entrypoint.sh
+++ b/director-mysql/19-alpine/docker-entrypoint.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env ash
 
 github_bareos='raw.githubusercontent.com/bareos/bareos'
-webui_admin_conf='master/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf'
-admin_conf='master/webui/install/bareos/bareos-dir.d/console/admin.conf.example'
+webui_admin_conf='Release/19.2.13/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf'
+admin_conf='Release/19.2.13/webui/install/bareos/bareos-dir.d/console/admin.conf.example'
 
 if [ ! -f /etc/bareos/bareos-config.control ]; then
   tar xzf /bareos-dir.tgz --backup=simple --suffix=.before-control

--- a/director-mysql/19-ubuntu/docker-entrypoint.sh
+++ b/director-mysql/19-ubuntu/docker-entrypoint.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 github_bareos='raw.githubusercontent.com/bareos/bareos'
-webui_admin_conf='master/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf'
-admin_conf='master/webui/install/bareos/bareos-dir.d/console/admin.conf.example'
+webui_admin_conf='Release/19.2.13/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf'
+admin_conf='Release/19.2.13/webui/install/bareos/bareos-dir.d/console/admin.conf.example'
 
 if [ ! -f /etc/bareos/bareos-config.control ]; then
   tar xzf /bareos-dir.tgz --backup=simple --suffix=.before-control

--- a/director-mysql/20-alpine/docker-entrypoint.sh
+++ b/director-mysql/20-alpine/docker-entrypoint.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env ash
 
 github_bareos='raw.githubusercontent.com/bareos/bareos'
-webui_admin_conf='master/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf'
-admin_conf='master/webui/install/bareos/bareos-dir.d/console/admin.conf.example'
+webui_admin_conf='Release/20.0.9/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf'
+admin_conf='Release/20.0.9/webui/install/bareos/bareos-dir.d/console/admin.conf.example'
 
 if [ ! -f /etc/bareos/bareos-config.control ]; then
   tar xzf /bareos-dir.tgz --backup=simple --suffix=.before-control

--- a/director-mysql/20-ubuntu/docker-entrypoint.sh
+++ b/director-mysql/20-ubuntu/docker-entrypoint.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 github_bareos='raw.githubusercontent.com/bareos/bareos'
-webui_admin_conf='master/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf'
-admin_conf='master/webui/install/bareos/bareos-dir.d/console/admin.conf.example'
+webui_admin_conf='Release/20.0.9/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf'
+admin_conf='Release/20.0.9/webui/install/bareos/bareos-dir.d/console/admin.conf.example'
 
 if [ ! -f /etc/bareos/bareos-config.control ]; then
   tar xzf /bareos-dir.tgz --backup=simple --suffix=.before-control

--- a/director-pgsql/16-ubuntu/docker-entrypoint.sh
+++ b/director-pgsql/16-ubuntu/docker-entrypoint.sh
@@ -1,23 +1,7 @@
 #!/usr/bin/env bash
 
-github_bareos='raw.githubusercontent.com/bareos/bareos'
-webui_admin_conf='master/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf'
-admin_conf='master/webui/install/bareos/bareos-dir.d/console/admin.conf.example'
-
 if [ ! -f /etc/bareos/bareos-config.control ]; then
   tar xzf /bareos-dir.tgz --backup=simple --suffix=.before-control
-
-  # Download default admin profile config
-  if [ ! -f /etc/bareos/bareos-dir.d/profile/webui-admin.conf ]; then
-    curl --silent --insecure "https://${github_bareos}/${webui_admin_conf}" \
-      --output /etc/bareos/bareos-dir.d/profile/webui-admin.conf
-  fi
-
-  # Download default webUI admin config
-  if [ ! -f /etc/bareos/bareos-dir.d/console/admin.conf ]; then
-    curl --silent --insecure "https://${github_bareos}/${admin_conf}" \
-      --output /etc/bareos/bareos-dir.d/console/admin.conf
-  fi
 
   # Update bareos-director configs
   # Director / mycatalog & mail report

--- a/director-pgsql/17-ubuntu/docker-entrypoint.sh
+++ b/director-pgsql/17-ubuntu/docker-entrypoint.sh
@@ -1,23 +1,7 @@
 #!/usr/bin/env bash
 
-github_bareos='raw.githubusercontent.com/bareos/bareos'
-webui_admin_conf='master/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf'
-admin_conf='master/webui/install/bareos/bareos-dir.d/console/admin.conf.example'
-
 if [ ! -f /etc/bareos/bareos-config.control ]; then
   tar xzf /bareos-dir.tgz --backup=simple --suffix=.before-control
-
-  # Download default admin profile config
-  if [ ! -f /etc/bareos/bareos-dir.d/profile/webui-admin.conf ]; then
-    curl --silent --insecure "https://${github_bareos}/${webui_admin_conf}" \
-      --output /etc/bareos/bareos-dir.d/profile/webui-admin.conf
-  fi
-
-  # Download default webUI admin config
-  if [ ! -f /etc/bareos/bareos-dir.d/console/admin.conf ]; then
-    curl --silent --insecure "https://${github_bareos}/${admin_conf}" \
-      --output /etc/bareos/bareos-dir.d/console/admin.conf
-  fi
 
   # Update bareos-director configs
   # Director / mycatalog & mail report

--- a/director-pgsql/18-ubuntu/docker-entrypoint.sh
+++ b/director-pgsql/18-ubuntu/docker-entrypoint.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 github_bareos='raw.githubusercontent.com/bareos/bareos'
-webui_admin_conf='master/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf'
-admin_conf='master/webui/install/bareos/bareos-dir.d/console/admin.conf.example'
+webui_admin_conf='Release/18.2.12/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf'
+admin_conf='Release/18.2.12/webui/install/bareos/bareos-dir.d/console/admin.conf.example'
 
 if [ ! -f /etc/bareos/bareos-config.control ]; then
   tar xzf /bareos-dir.tgz --backup=simple --suffix=.before-control

--- a/director-pgsql/19-alpine/docker-entrypoint.sh
+++ b/director-pgsql/19-alpine/docker-entrypoint.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env ash
 
 github_bareos='raw.githubusercontent.com/bareos/bareos'
-webui_admin_conf='master/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf'
-admin_conf='master/webui/install/bareos/bareos-dir.d/console/admin.conf.example'
+webui_admin_conf='Release/19.2.13/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf'
+admin_conf='Release/19.2.13/webui/install/bareos/bareos-dir.d/console/admin.conf.example'
 
 if [ ! -f /etc/bareos/bareos-config.control ]; then
   tar xzf /bareos-dir.tgz --backup=simple --suffix=.before-control

--- a/director-pgsql/19-ubuntu/docker-entrypoint.sh
+++ b/director-pgsql/19-ubuntu/docker-entrypoint.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 github_bareos='raw.githubusercontent.com/bareos/bareos'
-webui_admin_conf='master/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf'
-admin_conf='master/webui/install/bareos/bareos-dir.d/console/admin.conf.example'
+webui_admin_conf='Release/19.2.13/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf'
+admin_conf='Release/19.2.13/webui/install/bareos/bareos-dir.d/console/admin.conf.example'
 
 if [ ! -f /etc/bareos/bareos-config.control ]; then
   tar xzf /bareos-dir.tgz --backup=simple --suffix=.before-control

--- a/director-pgsql/20-alpine/docker-entrypoint.sh
+++ b/director-pgsql/20-alpine/docker-entrypoint.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env ash
 
 github_bareos='raw.githubusercontent.com/bareos/bareos'
-webui_admin_conf='master/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf'
-admin_conf='master/webui/install/bareos/bareos-dir.d/console/admin.conf.example'
+webui_admin_conf='Release/20.0.9/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf'
+admin_conf='Release/20.0.9/webui/install/bareos/bareos-dir.d/console/admin.conf.example'
 
 if [ ! -f /etc/bareos/bareos-config.control ]; then
   tar xzf /bareos-dir.tgz --backup=simple --suffix=.before-control

--- a/director-pgsql/20-ubuntu/docker-entrypoint.sh
+++ b/director-pgsql/20-ubuntu/docker-entrypoint.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 github_bareos='raw.githubusercontent.com/bareos/bareos'
-webui_admin_conf='master/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf'
-admin_conf='master/webui/install/bareos/bareos-dir.d/console/admin.conf.example'
+webui_admin_conf='Release/20.0.9/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf'
+admin_conf='Release/20.0.9/webui/install/bareos/bareos-dir.d/console/admin.conf.example'
 
 if [ ! -f /etc/bareos/bareos-config.control ]; then
   tar xzf /bareos-dir.tgz --backup=simple --suffix=.before-control

--- a/director-pgsql/21-alpine/docker-entrypoint.sh
+++ b/director-pgsql/21-alpine/docker-entrypoint.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env ash
 
 github_bareos='raw.githubusercontent.com/bareos/bareos'
-webui_admin_conf='master/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf'
-admin_conf='master/webui/install/bareos/bareos-dir.d/console/admin.conf.example'
+webui_admin_conf='Release/21.1.11/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf'
+admin_conf='Release/21.1.11/webui/install/bareos/bareos-dir.d/console/admin.conf.example'
 
 if [ ! -f /etc/bareos/bareos-config.control ]; then
   tar xzf /bareos-dir.tgz --backup=simple --suffix=.before-control

--- a/director-pgsql/21-ubuntu/docker-entrypoint.sh
+++ b/director-pgsql/21-ubuntu/docker-entrypoint.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 github_bareos='raw.githubusercontent.com/bareos/bareos'
-webui_admin_conf='master/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf'
-admin_conf='master/webui/install/bareos/bareos-dir.d/console/admin.conf.example'
+webui_admin_conf='Release/21.1.11/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf'
+admin_conf='Release/21.1.11/webui/install/bareos/bareos-dir.d/console/admin.conf.example'
 
 if [ ! -f /etc/bareos/bareos-config.control ]; then
   tar xzf /bareos-dir.tgz --backup=simple --suffix=.before-control

--- a/director-pgsql/22-alpine/docker-entrypoint.sh
+++ b/director-pgsql/22-alpine/docker-entrypoint.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env ash
 
 github_bareos='raw.githubusercontent.com/bareos/bareos'
-webui_admin_conf='master/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf'
-admin_conf='master/webui/install/bareos/bareos-dir.d/console/admin.conf.example'
+webui_admin_conf='Release/22.1.8/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf'
+admin_conf='Release/22.1.8/webui/install/bareos/bareos-dir.d/console/admin.conf.example'
 
 if [ ! -f /etc/bareos/bareos-config.control ]; then
   tar xzf /bareos-dir.tgz --backup=simple --suffix=.before-control

--- a/director-pgsql/24-ubuntu/docker-entrypoint.sh
+++ b/director-pgsql/24-ubuntu/docker-entrypoint.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 github_bareos='raw.githubusercontent.com/bareos/bareos'
-webui_admin_conf='master/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf'
-admin_conf='master/webui/install/bareos/bareos-dir.d/console/admin.conf.example'
+webui_admin_conf='Release/24.0.10/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf'
+admin_conf='Release/24.0.10/webui/install/bareos/bareos-dir.d/console/admin.conf.example'
 
 if [ ! -f /etc/bareos/bareos-config.control ]; then
   tar xzf /bareos-dir.tgz --backup=simple --suffix=.before-control

--- a/docker-compose-alpine-mysql-v2.yml
+++ b/docker-compose-alpine-mysql-v2.yml
@@ -67,7 +67,7 @@ services:
       - webui_data:/usr/share/bareos-webui
 
   bareos-db:
-    image: mysql:5.6
+    image: mysql:5.7
     volumes:
       - mysql_data:/var/lib/mysql
     environment:

--- a/docker-compose-alpine-mysql.yml
+++ b/docker-compose-alpine-mysql.yml
@@ -64,7 +64,7 @@ services:
       - /data/bareos/data/webui:/usr/share/bareos-webui
 
   bareos-db:
-    image: mysql:5.6
+    image: mysql:5.7
     volumes:
       - /data/mysql/data:/var/lib/mysql
     environment:

--- a/docker-compose-ubuntu-mysql.yml
+++ b/docker-compose-ubuntu-mysql.yml
@@ -60,7 +60,7 @@ services:
       - /data/bareos/config/webui:/etc/bareos-webui
 
   bareos-db:
-    image: mysql:5.6
+    image: mysql:5.7
     volumes:
       - /data/mysql/data:/var/lib/mysql
     environment:


### PR DESCRIPTION
mysql:5.6 is EOL and fails to start on modern kernels (6.x). mysql:5.7 is compatible with Bareos 19 and works on Ubuntu 24.04 runners.