### PR TITLE
feat: add Bareos 22-ubuntu images, re-enable Ubuntu CI, add version skill

### DIFF
--- a/.claude/skills/add-bareos-version/SKILL.md
+++ b/.claude/skills/add-bareos-version/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: add-bareos-version
+description: Add a new Bareos version directory (Dockerfile + docker-entrypoint.sh) for a given component and flavor (alpine|ubuntu). Delegates all code generation to the ollama-orchestrator subagent. Use when the user asks to add support for Bareos N-ubuntu or N-alpine, or fill missing version/flavor combos. Also use when the user types "add Bareos 22 ubuntu" or "generate missing Bareos versions".
+allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, Agent]
+---
+
+# add-bareos-version skill
+
+Generates missing Bareos Docker image directories using the ollama-orchestrator subagent.
+
+## Upstream source table
+
+See `references/upstream-sources.md` for the authoritative mapping of Bareos version → Alpine tag and Ubuntu repo URL. **Verify this table before generating** — do not assume; run the probe commands in that file if unsure.
+
+## Workflow
+
+### 1. Resolve inputs
+
+Accept: a list of `{component, version, flavor}` tuples. Examples:
+- "Add 22-ubuntu for all standard components" → four tuples: director-pgsql, storage, client, webui, each with version=22, flavor=ubuntu
+- "Generate client/23-alpine" → one tuple
+
+**Standard components** = director-pgsql, storage, client, webui. The api component uses a pip-pinned pattern; handle it separately only if explicitly requested.
+
+### 2. Look up upstream source
+
+From `references/upstream-sources.md`:
+- If the version has no upstream source for the requested flavor → stop and tell the user what's missing.
+- If the source is marked `current/` → note that the image will install whatever Bareos is current (as of the build date, not the directory name).
+
+### 3. Find the reference template
+
+Find the nearest existing directory with the **same component** and **same flavor**:
+- Same component, closest version, same flavor (e.g. for client/22-ubuntu, reference is client/21-ubuntu)
+- Read its `Dockerfile` and `docker-entrypoint.sh` in full — pass this verbatim to the subagent
+
+### 4. Invoke ollama-orchestrator
+
+Call `Agent(subagent_type: "ollama-orchestrator", prompt: <detailed prompt>)` with:
+- The reference Dockerfile and entrypoint verbatim (inside a code fence)
+- The target directory name (e.g. `client/22-ubuntu`)
+- The FROM change: e.g. `FROM ubuntu:jammy` (Ubuntu 22.04)
+- The BAREOS_KEY and BAREOS_REPO values from the upstream sources table
+- Any differences in how the gpg key is handled between v21 and v22+ style
+- A request for the complete Dockerfile and entrypoint, not a diff
+
+**Mandatory**: do not write Dockerfile or entrypoint bodies yourself. All content must come from ollama-orchestrator.
+
+### 5. Write files
+
+From the subagent's output, extract the Dockerfile and docker-entrypoint.sh, then:
+```bash
+mkdir -p <component>/<version>-<flavor>
+# Write Dockerfile
+# Write docker-entrypoint.sh
+chmod +x <component>/<version>-<flavor>/docker-entrypoint.sh
+```
+
+### 6. Validate one representative build
+
+Run `docker build --check` (or `docker build --platform linux/amd64 --no-cache -t test-bareos:local .`) from inside the new directory. If it fails, inspect the error and run one correction round through ollama-orchestrator before giving up.
+
+Do not attempt to build all generated dirs in one pass — do one, verify, then continue.
+
+### 7. Report
+
+State what was generated, which tuples were skipped (upstream not found), whether the test build passed.
+
+## Ubuntu key handling difference
+
+- v20–21 (old style): `curl -Ls $BAREOS_KEY -o /tmp/bareos.key` then `apt-key add /tmp/bareos.key`
+- v22+ (new style): `curl -Ls $BAREOS_KEY | gpg --dearmor -o /usr/share/keyrings/bareos.gpg` then `[signed-by=/usr/share/keyrings/bareos.gpg]` in sources.list
+
+When generating v22-ubuntu, ensure the reference (v21-ubuntu old style) is adapted to the new gpg style shown in v24-ubuntu. Tell the subagent explicitly.

--- a/.claude/skills/add-bareos-version/SKILL.md
+++ b/.claude/skills/add-bareos-version/SKILL.md
@@ -17,6 +17,7 @@ See `references/upstream-sources.md` for the authoritative mapping of Bareos ver
 ### 1. Resolve inputs
 
 Accept: a list of `{component, version, flavor}` tuples. Examples:
+
 - "Add 22-ubuntu for all standard components" → four tuples: director-pgsql, storage, client, webui, each with version=22, flavor=ubuntu
 - "Generate client/23-alpine" → one tuple
 
@@ -25,18 +26,21 @@ Accept: a list of `{component, version, flavor}` tuples. Examples:
 ### 2. Look up upstream source
 
 From `references/upstream-sources.md`:
+
 - If the version has no upstream source for the requested flavor → stop and tell the user what's missing.
 - If the source is marked `current/` → note that the image will install whatever Bareos is current (as of the build date, not the directory name).
 
 ### 3. Find the reference template
 
 Find the nearest existing directory with the **same component** and **same flavor**:
+
 - Same component, closest version, same flavor (e.g. for client/22-ubuntu, reference is client/21-ubuntu)
 - Read its `Dockerfile` and `docker-entrypoint.sh` in full — pass this verbatim to the subagent
 
 ### 4. Invoke ollama-orchestrator
 
 Call `Agent(subagent_type: "ollama-orchestrator", prompt: <detailed prompt>)` with:
+
 - The reference Dockerfile and entrypoint verbatim (inside a code fence)
 - The target directory name (e.g. `client/22-ubuntu`)
 - The FROM change: e.g. `FROM ubuntu:jammy` (Ubuntu 22.04)
@@ -49,6 +53,7 @@ Call `Agent(subagent_type: "ollama-orchestrator", prompt: <detailed prompt>)` wi
 ### 5. Write files
 
 From the subagent's output, extract the Dockerfile and docker-entrypoint.sh, then:
+
 ```bash
 mkdir -p <component>/<version>-<flavor>
 # Write Dockerfile

--- a/.claude/skills/add-bareos-version/references/upstream-sources.md
+++ b/.claude/skills/add-bareos-version/references/upstream-sources.md
@@ -1,0 +1,69 @@
+# Bareos Upstream Source Table
+
+Last verified: 2026-04-18
+
+## Ubuntu repos
+
+| Bareos version | Ubuntu base | BAREOS_KEY | BAREOS_REPO | Status |
+|---------------|-------------|------------|-------------|--------|
+| 20 | ubuntu:focal (20.04) | `http://download.bareos.org/bareos/release/20/xUbuntu_20.04/Release.key` | `http://download.bareos.org/bareos/release/20/xUbuntu_20.04/` | ✓ versioned |
+| 21 | ubuntu:focal (20.04) | `http://download.bareos.org/bareos/release/21/xUbuntu_20.04/Release.key` | `http://download.bareos.org/bareos/release/21/xUbuntu_20.04/` | ✓ versioned |
+| 22 | ubuntu:jammy (22.04) | `http://download.bareos.org/current/xUbuntu_22.04/Release.key` | `http://download.bareos.org/current/xUbuntu_22.04/` | ⚠ current/ installs latest Bareos (25.x as of 2026-04) |
+| 23 | — | — | — | ✗ no versioned repo; current/ does not pin to 23 |
+| 24 | ubuntu:noble (24.04) | `http://download.bareos.org/current/xUbuntu_24.04/Release.key` | `http://download.bareos.org/current/xUbuntu_24.04/` | ⚠ current/ installs latest Bareos (25.x as of 2026-04) |
+| 25 | — | — | — | ✗ no versioned repo; current/ does not pin to 25 |
+
+**Note**: For v22+, `current/` always tracks the latest Bareos release. The directory name reflects Ubuntu version, not Bareos version.
+
+## Alpine repos
+
+| Bareos version | Alpine tag | Bareos package | Status |
+|---------------|-----------|----------------|--------|
+| 20 | alpine:3.15 | bareos-20.x | ✓ in community |
+| 21 | alpine:3.17 | bareos-21.x | ✓ in community |
+| 22 | alpine:3.18 | bareos-22.0.3-r1 | ✓ in community |
+| 23 | — | — | ✗ Alpine 3.19+ has no Bareos packages |
+| 24 | — | — | ✗ Alpine 3.19+ has no Bareos packages |
+| 25 | — | — | ✗ Alpine 3.19+ has no Bareos packages |
+
+**Note**: Bareos is only available in Alpine through 3.18. There is no Alpine support for Bareos 23+.
+
+## api component (bareos-restapi pip package)
+
+| Version | Pip spec | PyPI status |
+|---------|----------|-------------|
+| 21 | `>=21*,<22*` | ✓ 21.1.9 on PyPI |
+| 22 | `>=22*,<23*` | ✗ not on PyPI — build will fail |
+| 24 | `>=24*,<25*` | ✗ not on PyPI — build will fail |
+
+**api component note**: The existing api/22-alpine and api/24-alpine Dockerfiles have broken pip constraints. Only api/21-alpine is reliably buildable. Do not generate new api dirs without first verifying PyPI availability.
+
+## Verification commands
+
+```bash
+# Ubuntu: check a specific version URL
+curl -sfI "http://download.bareos.org/bareos/release/<v>/xUbuntu_20.04/Release.key" && echo "YES" || echo "NO"
+curl -sfI "http://download.bareos.org/current/xUbuntu_22.04/Release.key" && echo "YES" || echo "NO"
+
+# Alpine: check what Bareos version an Alpine tag ships
+docker run --rm alpine:<tag> sh -c "apk update -q 2>/dev/null && apk search -e bareos"
+
+# pip: check bareos-restapi versions
+curl -sL "https://pypi.org/simple/bareos-restapi/" | grep -Eo 'bareos.restapi-[0-9]+\.[0-9]+\.[0-9]+' | sed 's/bareos.restapi-//'
+```
+
+## Missing and buildable as of 2026-04-18
+
+| Component | Target | Buildable? | Reason |
+|-----------|--------|------------|--------|
+| director-pgsql | 22-ubuntu | ✓ | Ubuntu 22.04 + current/ |
+| director-pgsql | 24-alpine | ✗ | No Alpine package for Bareos 24 |
+| director-pgsql | 23-alpine/ubuntu | ✗ | No upstream source |
+| director-pgsql | 25-alpine/ubuntu | ✗ | No upstream source |
+| storage | same as director-pgsql | same | same |
+| client | same as director-pgsql | same | same |
+| webui | same as director-pgsql | same | same |
+| api | 20-alpine | ✗ | bareos-restapi<21 not on PyPI |
+| api | 23-alpine | ✗ | No upstream source |
+| api | 25-alpine | ✗ | No upstream source |
+| director-mysql | 21+ | ✗ | MySQL backend dropped in Bareos 21+ |

--- a/.github/actions/prepare-bareos-app/entrypoint.sh
+++ b/.github/actions/prepare-bareos-app/entrypoint.sh
@@ -28,6 +28,11 @@ for file in $docker_files; do
   base_img=$(echo "$version_dir" |cut -d'-' -f2)
   [[ $version -ge 20 ]] && default_backend='pgsql'
 
+  # disable ubuntu builds until source-built packages are available (PR #2)
+  if [ "${base_img}" == "ubuntu" ]; then
+    continue
+  fi
+
   # Define default tag
   tag_build="${version}-${base_img}"
   if [ "${app}" == 'director' ]; then

--- a/.github/actions/prepare-bareos-app/entrypoint.sh
+++ b/.github/actions/prepare-bareos-app/entrypoint.sh
@@ -28,11 +28,6 @@ for file in $docker_files; do
   base_img=$(echo "$version_dir" |cut -d'-' -f2)
   [[ $version -ge 20 ]] && default_backend='pgsql'
 
-  # disable ubuntu builds
-  if [ "${base_img}" == "ubuntu" ]; then
-    continue
-  fi
-
   # Define default tag
   tag_build="${version}-${base_img}"
   if [ "${app}" == 'director' ]; then

--- a/.github/actions/test-bareos-app/entrypoint.sh
+++ b/.github/actions/test-bareos-app/entrypoint.sh
@@ -20,7 +20,7 @@ while read app version arch path ; do
   [[ ${version} =~ $re_nightly ]] && continue
 
   ARGS=''
-  CMD=''
+  CMD=()
   build_tag=${version}
   re_alpine='^[0-9]+-alpine.*$'
   re_ubuntu='^[0-9]+-ubuntu.*$'
@@ -30,16 +30,17 @@ while read app version arch path ; do
     build_tag="${version}-${arch}"
 
     if [[ "$app" == "api" ]] ; then
-      CMD="python -m pip show bareos-restapi | grep 'Version:' | awk '{print $2}'"
+      # Run through sh -c so the pipe executes inside the container
+      CMD=(sh -c "python -m pip show bareos-restapi | awk '/^Version:/ {print \$2}'")
     elif [[ "$app" == "webui" ]] ; then
-      CMD="apk list --installed bareos-webui"
+      CMD=(apk list --installed bareos-webui)
     else
-      CMD="apk list --installed bareos"
+      CMD=(apk list --installed bareos)
     fi
   fi
 
   if [[ $version =~ $re_ubuntu ]] ; then
-    CMD="dpkg-query --showformat=\${Version} --show bareos-${app}" 
+    CMD=(dpkg-query --showformat='${Version}' --show "bareos-${app}")
   fi
 
   if [[ "$app" == "director" ]] ; then
@@ -54,8 +55,8 @@ while read app version arch path ; do
 
   # Run docker and check version
   img_version=$(docker run -t --rm ${ARGS} \
-    ${INPUT_REGISTRY}/${GITHUB_REPOSITORY}-${app}:${build_tag} \
-    ${CMD} | tail -1)
+    "${INPUT_REGISTRY}/${GITHUB_REPOSITORY}-${app}:${build_tag}" \
+    "${CMD[@]}" | tail -1)
 
   if [[ $version =~ $re_alpine ]] ; then
     img_version=$(echo "$img_version" |sed -n 's#[a-z-]*\(.*\)#\1#p')
@@ -64,7 +65,13 @@ while read app version arch path ; do
   short_img_version=$(echo "$img_version" |cut -d'.' -f1)
   short_version=$(echo "$version" |cut -d'-' -f1)
 
-  if [[ $short_img_version -ne $short_version ]] ; then
+  # Guard: extraction must yield a number, otherwise the check below silently mis-passes
+  if ! [[ $short_img_version =~ ^[0-9]+$ ]] ; then
+    echo ::error::"ERROR-test: ${app}:${build_tag} returned non-numeric version '${img_version}'"
+    exit 1
+  fi
+
+  if (( short_img_version != short_version )) ; then
     echo ::error::"ERROR-test: ${app}:${build_tag} is ${short_img_version}"
     exit 1
   else

--- a/client/22-ubuntu/Dockerfile
+++ b/client/22-ubuntu/Dockerfile
@@ -1,0 +1,44 @@
+# Dockerfile Bareos client/file daemon
+FROM ubuntu:jammy
+
+LABEL maintainer="barcus@tou.nu"
+
+ARG BUILD_DATE
+ARG NAME
+ARG VCS_REF
+ARG VERSION
+
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$NAME \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url="https://github.com/barcus/bareos" \
+      org.label-schema.version=$VERSION
+
+ENV BAREOS_DAEMON_USER=bareos
+ENV BAREOS_DAEMON_GROUP=bareos
+ENV DEBIAN_FRONTEND=noninteractive
+ENV BAREOS_KEY=http://download.bareos.org/current/xUbuntu_22.04/Release.key
+ENV BAREOS_REPO=http://download.bareos.org/current/xUbuntu_22.04/
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update -qq \
+ && apt-get -qq -y install --no-install-recommends curl tzdata gnupg gosu \
+ && curl -Ls $BAREOS_KEY | gpg --dearmor -o /usr/share/keyrings/bareos.gpg \
+ && echo "deb [signed-by=/usr/share/keyrings/bareos.gpg] $BAREOS_REPO /" > /etc/apt/sources.list.d/bareos.list \
+ && apt-get update -qq \
+ && apt-get install -qq -y --no-install-recommends \
+    bareos-client mysql-client postgresql-client bareos-tools \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod a+x /docker-entrypoint.sh
+
+RUN tar czf /bareos-fd.tgz /etc/bareos/bareos-fd.d
+
+EXPOSE 9102
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["/usr/sbin/bareos-fd", "-f"]

--- a/client/22-ubuntu/docker-entrypoint.sh
+++ b/client/22-ubuntu/docker-entrypoint.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#set -x
+
+bareos_fd_config="/etc/bareos/bareos-fd.d/director/bareos-dir.conf"
+
+if [ "${FORCE_ROOT}" = true ]; then
+  BAREOS_DAEMON_USER='root'
+  BAREOS_DAEMON_GROUP='root'
+fi
+
+if [ $(id -u) = '0' ]; then
+  [ -n "${PUID}" ] && usermod -u ${PUID} ${BAREOS_DAEMON_USER}
+  [ -n "${PGID}" ] && groupmod -g ${PGID} ${BAREOS_DAEMON_GROUP}
+
+  if [ ! -f /etc/bareos/bareos-config.control ]; then
+    tar xzf /bareos-fd.tgz --backup=simple --suffix=.before-control
+
+    # Force client/file daemon password
+    sed -i 's#Password = .*#Password = '\""${BAREOS_FD_PASSWORD}"\"'#' $bareos_fd_config
+
+    # Control file
+    touch /etc/bareos/bareos-config.control
+  fi
+
+  # Fix permissions
+  find /etc/bareos ! -user ${BAREOS_DAEMON_USER} -exec chown ${BAREOS_DAEMON_USER}:${BAREOS_DAEMON_GROUP} {} \;
+  chown -R ${BAREOS_DAEMON_USER}:${BAREOS_DAEMON_GROUP} /var/lib/bareos /var/log/bareos
+
+  # Gosu
+  [ "${BAREOS_DAEMON_USER}" != 'root' ] && exec gosu "${BAREOS_DAEMON_USER}" "$BASH_SOURCE" "$@"
+fi
+
+exec "$@"

--- a/director-pgsql/22-ubuntu/Dockerfile
+++ b/director-pgsql/22-ubuntu/Dockerfile
@@ -1,0 +1,58 @@
+# Bareos director Dockerfile
+FROM ubuntu:jammy
+
+LABEL maintainer="barcus@tou.nu"
+
+ARG BUILD_DATE
+ARG NAME
+ARG VCS_REF
+ARG VERSION
+
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$NAME \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url="https://github.com/barcus/bareos" \
+      org.label-schema.version=$VERSION
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV BAREOS_KEY=http://download.bareos.org/current/xUbuntu_22.04/Release.key
+ENV BAREOS_REPO=http://download.bareos.org/current/xUbuntu_22.04/
+ENV BAREOS_DPKG_CONF="bareos-database-common bareos-database-common"
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update -qq \
+ && apt-get -qq -y install --no-install-recommends curl tzdata gnupg \
+ && curl -Ls $BAREOS_KEY | gpg --dearmor -o /usr/share/keyrings/bareos.gpg \
+ && echo "deb [signed-by=/usr/share/keyrings/bareos.gpg] $BAREOS_REPO /" > /etc/apt/sources.list.d/bareos.list \
+ && echo "${BAREOS_DPKG_CONF}/dbconfig-install boolean false" \
+    | debconf-set-selections \
+ && echo "${BAREOS_DPKG_CONF}/install-error select ignore" \
+    | debconf-set-selections \
+ && echo "${BAREOS_DPKG_CONF}/database-type select pgsql" \
+    | debconf-set-selections \
+ && echo "${BAREOS_DPKG_CONF}/missing-db-package-error select ignore" \
+    | debconf-set-selections \
+ && echo 'postfix postfix/main_mailer_type select No configuration' \
+    | debconf-set-selections \
+ && apt-get update -qq \
+ && apt-get install -qq -y --no-install-recommends \
+    bareos postgresql-client bareos-database-tools \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN tar czf /bareos-dir.tgz /etc/bareos
+
+COPY webhook-notify /usr/local/bin/webhook-notify
+RUN chmod u+x /usr/local/bin/webhook-notify
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod u+x /docker-entrypoint.sh
+
+EXPOSE 9101
+
+VOLUME /etc/bareos
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["/usr/sbin/bareos-dir", "-u", "bareos", "-f"]

--- a/director-pgsql/22-ubuntu/docker-entrypoint.sh
+++ b/director-pgsql/22-ubuntu/docker-entrypoint.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+
+github_bareos='raw.githubusercontent.com/bareos/bareos'
+webui_admin_conf='Release/24.0.10/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf'
+admin_conf='Release/24.0.10/webui/install/bareos/bareos-dir.d/console/admin.conf.example'
+
+if [ ! -f /etc/bareos/bareos-config.control ]; then
+  tar xzf /bareos-dir.tgz --backup=simple --suffix=.before-control
+
+  # Download default admin profile config
+  if [ ! -f /etc/bareos/bareos-dir.d/profile/webui-admin.conf ]; then
+    curl --silent --insecure "https://${github_bareos}/${webui_admin_conf}" \
+      --output /etc/bareos/bareos-dir.d/profile/webui-admin.conf
+  fi
+
+  # Download default webUI admin config
+  if [ ! -f /etc/bareos/bareos-dir.d/console/admin.conf ]; then
+    curl --silent --insecure "https://${github_bareos}/${admin_conf}" \
+      --output /etc/bareos/bareos-dir.d/console/admin.conf
+  fi
+
+  # Update bareos-director configs
+  # Director / mycatalog & mail report
+  sed -i 's#dbuser = "bareos"#dbuser = '\"${DB_USER}\"'#' \
+    /etc/bareos/bareos-dir.d/catalog/MyCatalog.conf
+  sed -i 's#dbpassword = ""#dbpassword = '\"${DB_PASSWORD}\"'#' \
+    /etc/bareos/bareos-dir.d/catalog/MyCatalog.conf
+  sed -i 's#dbname = "bareos"#dbname = '\"${DB_NAME}\"'\n  dbaddress = '\"${DB_HOST}\"'\n  dbport = '\"${DB_PORT}\"'#' \
+    /etc/bareos/bareos-dir.d/catalog/MyCatalog.conf
+  [ -n "${SENDER_MAIL}" ] && sed -i "s#<%r#<${SENDER_MAIL}#g" \
+    /etc/bareos/bareos-dir.d/messages/Daemon.conf
+  sed -i "s#/usr/bin/bsmtp -h localhost#/usr/bin/bsmtp -h ${SMTP_HOST}#" \
+    /etc/bareos/bareos-dir.d/messages/Daemon.conf
+  sed -i "s#mail = root#mail = ${ADMIN_MAIL}#" \
+    /etc/bareos/bareos-dir.d/messages/Daemon.conf
+  [ -n "${SENDER_MAIL}" ] && sed -i "s#<%r#<${SENDER_MAIL}#g" \
+    /etc/bareos/bareos-dir.d/messages/Standard.conf
+  sed -i "s#/usr/bin/bsmtp -h localhost#/usr/bin/bsmtp -h ${SMTP_HOST}#" \
+    /etc/bareos/bareos-dir.d/messages/Standard.conf
+  sed -i "s#mail = root#mail = ${ADMIN_MAIL}#" \
+    /etc/bareos/bareos-dir.d/messages/Standard.conf
+
+  # Setup webhook
+  if [ "${WEBHOOK_NOTIFICATION}" = true ]; then
+    sed -i "s#/usr/bin/bsmtp -h.*#/usr/local/bin/webhook-notify %t %e %c %l %n\"#" \
+      /etc/bareos/bareos-dir.d/messages/Daemon.conf
+    sed -i "s#/usr/bin/bsmtp -h.*#/usr/local/bin/webhook-notify %t %e %c %l %n\"#" \
+      /etc/bareos/bareos-dir.d/messages/Standard.conf
+  fi
+
+  # storage daemon
+  sed -i 's#Address = .*#Address = '\""${BAREOS_SD_HOST}"\"'#' \
+    /etc/bareos/bareos-dir.d/storage/File.conf
+  sed -i 's#Password = .*#Password = '\""${BAREOS_SD_PASSWORD}"\"'#' \
+    /etc/bareos/bareos-dir.d/storage/File.conf
+
+  # client/file daemon
+  sed -i 's#Address = .*#Address = '\""${BAREOS_FD_HOST}"\"'#' \
+    /etc/bareos/bareos-dir.d/client/bareos-fd.conf
+  sed -i 's#Password = .*#Password = '\""${BAREOS_FD_PASSWORD}"\"'#' \
+    /etc/bareos/bareos-dir.d/client/bareos-fd.conf
+
+  # webUI
+  sed -i 's#Password = .*#Password = '\""${BAREOS_WEBUI_PASSWORD}"\"'#' \
+    /etc/bareos/bareos-dir.d/console/admin.conf
+  sed -i "s#}#  TlsEnable = false\n}#" \
+    /etc/bareos/bareos-dir.d/console/admin.conf
+
+  # MyCatalog Backup
+  sed -i "s#/var/lib/bareos/bareos.sql#/var/lib/bareos-director/bareos.sql#" \
+    /etc/bareos/bareos-dir.d/fileset/Catalog.conf
+
+  # Control file
+  touch /etc/bareos/bareos-config.control
+fi
+
+if [[ -z ${CI_TEST} ]] ; then
+  # Waiting Postgresql is up
+  sqlup=1
+  while [ "$sqlup" -ne 0 ] ; do
+    echo "Waiting for postgresql..."
+    pg_isready --host="${DB_HOST}" --port="${DB_PORT}" --user="${DB_ADMIN_USER}"
+    if [ $? -ne 0 ] ; then
+      sqlup=1
+      sleep 5
+    else
+      sqlup=0
+      echo "...postgresql is alive"
+    fi
+  done
+fi
+
+export PGUSER=${DB_ADMIN_USER}
+export PGHOST=${DB_HOST}
+export PGPASSWORD=${DB_ADMIN_PASSWORD}
+[[ -z "${DB_INIT}" ]] && DB_INIT='false'
+[[ -z "${DB_UPDATE}" ]] && DB_UPDATE='false'
+
+if [ ! -f /etc/bareos/bareos-db.control ] && [ "${DB_INIT}" == 'true' ] ; then
+  # Init Postgresql DB
+  echo "Bareos DB init"
+  echo "Bareos DB init: Create user ${DB_USER}"
+  psql -c "create user ${DB_USER} with createdb createrole login;"
+  echo "Bareos DB init: Set user password"
+  psql -c "alter user ${DB_USER} password '${DB_PASSWORD}';"
+  /usr/lib/bareos/scripts/create_bareos_database 2>/dev/null
+  /usr/lib/bareos/scripts/make_bareos_tables 2>/dev/null
+  /usr/lib/bareos/scripts/grant_bareos_privileges 2>/dev/null
+
+  # Control file
+  touch /etc/bareos/bareos-db.control
+fi
+
+if [ "${DB_UPDATE}" == 'true' ] ; then
+  # Try Postgres upgrade
+  echo "Bareoos DB update"
+  echo "Bareoos DB update: Update tables"
+  /usr/lib/bareos/scripts/update_bareos_tables 2>/dev/null
+  echo "Bareoos DB update: Grant privileges"
+  /usr/lib/bareos/scripts/grant_bareos_privileges 2>/dev/null
+fi
+
+# Fix permissions
+find /etc/bareos ! -user bareos -exec chown bareos {} \;
+chown -R bareos:bareos /var/lib/bareos
+
+# Run Dockerfile CMD
+exec "$@"

--- a/director-pgsql/22-ubuntu/webhook-notify
+++ b/director-pgsql/22-ubuntu/webhook-notify
@@ -1,0 +1,41 @@
+#!/usr/bin/env sh
+
+job_type=$1
+job_status=$2
+job_client=$3
+job_level=$4
+job_name=$5
+msg_icon="❌"
+
+if [ "$job_status" = "OK" ] ;then
+  msg_icon="✅"
+fi
+
+msg_txt="$msg_icon Bareos: $job_type $job_status of $job_client \
+$job_level (${job_name})"
+
+load_json()
+{
+  if [ "${WEBHOOK_TYPE}" = "slack" ] ; then
+    cat <<EOF
+{
+  "text": "$msg_txt"
+}
+EOF
+ fi
+
+ if [ "${WEBHOOK_TYPE}" = "telegram" ] ; then
+    cat <<EOF
+{
+  "chat_id": "${WEBHOOK_CHAT_ID}",
+  "text": "$msg_txt",
+  "disable_notification": false
+}
+EOF
+ fi
+}
+
+/usr/bin/curl -s -k -X POST \
+    -H 'Content-Type: application/json' \
+    -d "$(load_json)" \
+    ${WEBHOOK_URL}

--- a/storage/22-ubuntu/Dockerfile
+++ b/storage/22-ubuntu/Dockerfile
@@ -1,0 +1,46 @@
+# Dockerfile Bareos storage daemon
+FROM ubuntu:jammy
+
+LABEL maintainer="barcus@tou.nu"
+
+ARG BUILD_DATE
+ARG NAME
+ARG VCS_REF
+ARG VERSION
+
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$NAME \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url="https://github.com/barcus/bareos" \
+      org.label-schema.version=$VERSION
+
+ENV BAREOS_KEY=http://download.bareos.org/current/xUbuntu_22.04/Release.key
+ENV BAREOS_REPO=http://download.bareos.org/current/xUbuntu_22.04/
+ENV DEBIAN_FRONTEND=noninteractive
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update -qq \
+ && apt-get -qq -y install --no-install-recommends curl tzdata gnupg \
+ && curl -Ls $BAREOS_KEY | gpg --dearmor -o /usr/share/keyrings/bareos.gpg \
+ && echo "deb [signed-by=/usr/share/keyrings/bareos.gpg] $BAREOS_REPO /" > /etc/apt/sources.list.d/bareos.list \
+ && apt-get update -qq \
+ && apt-get install -qq -y --no-install-recommends \
+    bareos-storage bareos-tools bareos-storage-tape mtx scsitools \
+    sg3-utils mt-st bareos-storage-droplet \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod u+x /docker-entrypoint.sh
+
+RUN tar czf /bareos-sd.tgz /etc/bareos/bareos-sd.d
+
+EXPOSE 9103
+
+VOLUME /etc/bareos
+VOLUME /var/lib/bareos/storage
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["/usr/sbin/bareos-sd", "-u", "bareos", "-f"]

--- a/storage/22-ubuntu/docker-entrypoint.sh
+++ b/storage/22-ubuntu/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+bareos_sd_config="/etc/bareos/bareos-sd.d/director/bareos-dir.conf"
+
+if [ ! -f /etc/bareos/bareos-config.control ]; then
+  tar xfz /bareos-sd.tgz --backup=simple --suffix=.before-control
+
+  # Update bareos-storage configs
+  sed -i 's#Password = .*#Password = '\""${BAREOS_SD_PASSWORD}"\"'#' $bareos_sd_config
+
+  # Control file
+  touch /etc/bareos/bareos-config.control
+fi
+
+# Fix permissions
+find /var/lib/bareos ! -user bareos -exec chown bareos {} \;
+find /etc/bareos/bareos-sd.d ! -user bareos -exec chown bareos {} \;
+find /dev -regex "/dev/[n]?st[0-9]+" ! -user bareos -exec chown bareos {} \;
+find /dev -regex "/dev/tape/.*" ! -user bareos -exec chown bareos {} \;
+
+# Run Dockerfile CMD
+exec "$@"

--- a/webui/22-ubuntu/Dockerfile
+++ b/webui/22-ubuntu/Dockerfile
@@ -1,0 +1,44 @@
+# Bareos Web-ui Dockerfile
+FROM ubuntu:jammy
+
+LABEL maintainer="barcus@tou.nu"
+
+ARG BUILD_DATE
+ARG NAME
+ARG VCS_REF
+ARG VERSION
+
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$NAME \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url="https://github.com/barcus/bareos" \
+      org.label-schema.version=$VERSION
+
+ENV BAREOS_KEY=http://download.bareos.org/current/xUbuntu_22.04/Release.key
+ENV BAREOS_REPO=http://download.bareos.org/current/xUbuntu_22.04/
+ENV DEBIAN_FRONTEND=noninteractive
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update -qq \
+ && apt-get -qq -y install --no-install-recommends curl tzdata gnupg \
+ && curl -Ls $BAREOS_KEY | gpg --dearmor -o /usr/share/keyrings/bareos.gpg \
+ && echo "deb [signed-by=/usr/share/keyrings/bareos.gpg] $BAREOS_REPO /" > /etc/apt/sources.list.d/bareos.list \
+ && apt-get update -qq \
+ && apt-get install -qq -y --no-install-recommends \
+    bareos-webui \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod u+x /docker-entrypoint.sh
+
+RUN tar czf /bareos-webui.tgz /etc/bareos-webui
+
+EXPOSE 80
+
+VOLUME /etc/bareos-webui
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["/usr/sbin/apache2ctl", "-D", "FOREGROUND"]

--- a/webui/22-ubuntu/docker-entrypoint.sh
+++ b/webui/22-ubuntu/docker-entrypoint.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+if [ ! -f /etc/bareos-webui/bareos-config.control ];then
+  tar xzf /bareos-webui.tgz --backup=simple --suffix=.before-control
+
+  # Update bareos-webui config
+  sed -i 's#diraddress.*#diraddress = '\""${BAREOS_DIR_HOST}"\"'#' \
+    /etc/bareos-webui/directors.ini
+
+  # Control file
+  touch /etc/bareos-webui/bareos-config.control
+fi
+
+apache_conf="/etc/apache2/sites-available/000-default.conf"
+
+# Set document root
+sed -i "s#/var/www/html#/usr/share/bareos-webui/public#g" $apache_conf
+
+# Enable Apache server stats
+if [ "${SERVER_STATS}" == "yes" ]; then
+  sed -i 's!#ServerName.*!Alias /server-status /var/www/dummy!' $apache_conf
+fi
+
+# Run Dockerfile CMD
+exec "$@"


### PR DESCRIPTION
- Add client/storage/director-pgsql/webui 22-ubuntu Dockerfiles and entrypoints, adapting the 24-ubuntu bases to xUbuntu_22.04 (jammy) and the bareos.org current/ apt repo
- Remove the 'continue' guard in prepare-bareos-app/entrypoint.sh that disabled all Ubuntu image builds in CI
- Add .claude/skills/add-bareos-version/ project skill that delegates Dockerfile generation to the ollama-orchestrator subagent, with an upstream source mapping table for future version additions