### PR TITLE
feat: add bareos-packages/ from-source .deb builder for Ubuntu 22-24

### DIFF
--- a/.github/workflows/build-bareos-packages.yml
+++ b/.github/workflows/build-bareos-packages.yml
@@ -1,0 +1,84 @@
+name: build-bareos-packages
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 4 * * 0'
+  push:
+    paths:
+      - 'bareos-packages/**'
+      - '.github/workflows/build-bareos-packages.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - bareos_branch: bareos-22
+            ubuntu_codename: jammy
+          - bareos_branch: bareos-23
+            ubuntu_codename: jammy
+          - bareos_branch: bareos-24
+            ubuntu_codename: noble
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build ${{ matrix.bareos_branch }} / ${{ matrix.ubuntu_codename }} packages
+        run: |
+          docker build \
+            -f bareos-packages/Dockerfile.builder.${{ matrix.ubuntu_codename }} \
+            -t bareos-builder:${{ matrix.ubuntu_codename }} \
+            bareos-packages/
+          mkdir -p artifacts
+          docker run --rm \
+            -v "${{ github.workspace }}/artifacts:/artifacts" \
+            -e BAREOS_BRANCH=${{ matrix.bareos_branch }} \
+            -e UBUNTU_CODENAME=${{ matrix.ubuntu_codename }} \
+            bareos-builder:${{ matrix.ubuntu_codename }}
+
+      - name: List produced packages
+        run: ls -lh artifacts/${{ matrix.bareos_branch }}/${{ matrix.ubuntu_codename }}/
+
+      - name: Upload packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: debs-${{ matrix.bareos_branch }}-${{ matrix.ubuntu_codename }}
+          path: artifacts/${{ matrix.bareos_branch }}/${{ matrix.ubuntu_codename }}/
+          retention-days: 30
+
+  release:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/pkg/')
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - bareos_branch: bareos-22
+            ubuntu_codename: jammy
+          - bareos_branch: bareos-23
+            ubuntu_codename: jammy
+          - bareos_branch: bareos-24
+            ubuntu_codename: noble
+
+    steps:
+      - name: Download packages
+        uses: actions/download-artifact@v4
+        with:
+          name: debs-${{ matrix.bareos_branch }}-${{ matrix.ubuntu_codename }}
+          path: debs/
+
+      - name: Create release tarball
+        run: |
+          tar czf ${{ matrix.bareos_branch }}-${{ matrix.ubuntu_codename }}.tar.gz \
+            -C debs/ .
+
+      - name: Publish to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ matrix.bareos_branch }}-${{ matrix.ubuntu_codename }}.tar.gz

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,7 @@ GitHub Actions workflows in `.github/workflows/`:
 
 - `ci-director.yml`, `ci-client.yml`, `ci-storage.yml`, `ci-webui.yml`, `ci-api.yml` — build and push images; triggered on changes to the respective component directories
 - `run-compose.yml` — integration test: spins up each compose variant and runs `bconsole` to verify the stack is healthy (runs weekly on Sundays and on compose file changes)
+- `build-bareos-packages.yml` — builds `.deb` packages from the bareos source repo for versions not available on `download.bareos.org`; see `bareos-packages/README.md`
 - `test-n-lint.yml` — linting
 - `push-readme.yml` — syncs README to Docker Hub
 
@@ -98,5 +99,22 @@ The CI uses reusable composite actions in `.github/actions/` (prepare, build, pu
 ## Version Support
 
 - Alpine images support `linux/amd64` and `linux/arm64/v8`
-- Current active versions: 24 (Ubuntu and Alpine), 22 (Alpine)
+- Current active versions: 22 (Ubuntu and Alpine), 24 (Ubuntu)
 - MySQL backend was dropped in Bareos 21+; `director-mysql/` only goes up to version 20
+
+### Upstream package availability
+
+`download.bareos.org` only publishes versioned repos for Bareos 20 and 21. For 22+:
+
+| Bareos version | Ubuntu                          | Alpine            |
+|----------------|---------------------------------|-------------------|
+| 20             | versioned apt repo              | Alpine 3.15       |
+| 21             | versioned apt repo              | Alpine 3.17       |
+| 22             | `current/` (serves 25.x today) | Alpine 3.18       |
+| 23             | not published upstream          | not published     |
+| 24             | not published upstream          | not published     |
+| 25             | `current/` (latest)            | not published     |
+
+Use `bareos-packages/` to build `.deb` packages from source for versions 22–24.
+Once packages are published as GitHub Releases, use the `.claude/skills/add-bareos-version`
+skill to generate new component directories that install from those artifacts.

--- a/bareos-packages/Dockerfile.builder.jammy
+++ b/bareos-packages/Dockerfile.builder.jammy
@@ -1,0 +1,19 @@
+FROM ubuntu:jammy
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update -qq \
+ && apt-get install -qq -y --no-install-recommends \
+    git ca-certificates build-essential devscripts debhelper cmake \
+    equivs fakeroot dpkg-dev \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY build.sh /build.sh
+RUN chmod +x /build.sh
+
+VOLUME /artifacts
+
+ENTRYPOINT ["/build.sh"]

--- a/bareos-packages/Dockerfile.builder.noble
+++ b/bareos-packages/Dockerfile.builder.noble
@@ -1,0 +1,19 @@
+FROM ubuntu:noble
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update -qq \
+ && apt-get install -qq -y --no-install-recommends \
+    git ca-certificates build-essential devscripts debhelper cmake \
+    equivs fakeroot dpkg-dev \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY build.sh /build.sh
+RUN chmod +x /build.sh
+
+VOLUME /artifacts
+
+ENTRYPOINT ["/build.sh"]

--- a/bareos-packages/README.md
+++ b/bareos-packages/README.md
@@ -1,0 +1,99 @@
+# bareos-packages — Bareos .deb builder from source
+
+Builds Bareos `.deb` packages from the upstream [bareos/bareos](https://github.com/bareos/bareos)
+release branches for (Bareos version, Ubuntu codename) combinations that
+`download.bareos.org` does not publish.
+
+## Why
+
+`download.bareos.org/current/` only serves the latest Bareos release (25.x as of 2026).
+Versioned repos exist only for Bareos 20 and 21. This builder covers the gap:
+
+| Bareos branch | Ubuntu codename | Published by upstream? |
+|---------------|-----------------|------------------------|
+| bareos-22     | jammy (22.04)   | no — build from source |
+| bareos-23     | jammy (22.04)   | no — build from source |
+| bareos-24     | noble (24.04)   | no — build from source |
+| bareos-25     | jammy / noble   | yes — `current/`       |
+
+## Build locally
+
+```bash
+# Build the jammy builder image
+docker build -f Dockerfile.builder.jammy -t bareos-builder:jammy .
+
+# Build Bareos 22 packages for jammy (takes 20–40 min on 4 cores)
+mkdir -p ../artifacts
+docker run --rm \
+  -v "$(pwd)/../artifacts:/artifacts" \
+  -e BAREOS_BRANCH=bareos-22 \
+  -e UBUNTU_CODENAME=jammy \
+  bareos-builder:jammy
+
+# Packages land in: ../artifacts/bareos-22/jammy/*.deb
+ls ../artifacts/bareos-22/jammy/
+```
+
+Replace `jammy` with `noble` and `bareos-22` with `bareos-24` for the noble variant.
+
+## CI / GitHub Actions
+
+Workflow: `.github/workflows/build-bareos-packages.yml`
+
+- **Manual trigger** (`workflow_dispatch`): builds all three matrix cells.
+- **Scheduled**: Sundays at 04:00 UTC to pick up upstream branch fixes.
+- **On push** to `bareos-packages/**`: rebuilds on builder file changes.
+
+Artifacts are uploaded (30-day retention) as `debs-<branch>-<codename>`.
+
+## Publishing a GitHub Release
+
+Tag the repo with `pkg/<branch>-<codename>-vN` (e.g. `pkg/bareos-22-jammy-v1`) after
+a successful workflow run. The `release` job picks up the artifacts and attaches
+`bareos-22-jammy.tar.gz` (etc.) to the release.
+
+```bash
+git tag pkg/bareos-22-jammy-v1
+git push origin pkg/bareos-22-jammy-v1
+```
+
+## Consuming packages in component Dockerfiles
+
+Once a release exists, component Dockerfiles can install from it:
+
+```dockerfile
+ARG BAREOS_PKG_RELEASE=pkg/bareos-22-jammy-v1
+ARG BAREOS_PKG_REPO=https://github.com/<owner>/<repo>
+
+ADD ${BAREOS_PKG_REPO}/releases/download/${BAREOS_PKG_RELEASE}/bareos-22-jammy.tar.gz /tmp/bareos-pkgs.tar.gz
+
+RUN mkdir -p /tmp/bareos-debs \
+ && tar -xzf /tmp/bareos-pkgs.tar.gz -C /tmp/bareos-debs \
+ && apt-get update -qq \
+ && apt-get install -qq -y --no-install-recommends \
+    tzdata gosu postgresql-client \
+    /tmp/bareos-debs/bareos-common_*.deb \
+    /tmp/bareos-debs/bareos-filedaemon_*.deb \
+    /tmp/bareos-debs/bareos-tools_*.deb \
+ && rm -rf /tmp/bareos-pkgs.tar.gz /tmp/bareos-debs \
+ && apt-get clean && rm -rf /var/lib/apt/lists/*
+```
+
+Package names per component (from the bareos debian/ tree):
+
+| Component      | .deb packages to install                                                          |
+|----------------|-----------------------------------------------------------------------------------|
+| client (fd)    | `bareos-common`, `bareos-filedaemon`, `bareos-tools`                              |
+| storage (sd)   | `bareos-common`, `bareos-storage`, `bareos-storage-tape`, `bareos-tools`          |
+| director-pgsql | `bareos-common`, `bareos-director`, `bareos-database-common`,                     |
+|                | `bareos-database-postgresql`, `bareos-database-tools`                             |
+| webui          | `bareos-webui`                                                                    |
+
+Use the `.claude/skills/add-bareos-version` skill to generate component directories once
+a release is published — it handles the Dockerfile template and entrypoint wiring.
+
+## Notes
+
+- `bareos-storage-droplet` (S3 plugin) may not appear in all version branches; skip if absent.
+- Build time: 20–40 min per matrix cell on a 4-core runner.
+- Alpine source-build is deferred; no upstream APKBUILD exists for Bareos.

--- a/bareos-packages/build.sh
+++ b/bareos-packages/build.sh
@@ -38,7 +38,11 @@ case "${BAREOS_BRANCH}" in
             libcli11-dev libfmt-dev libmsgsl-dev \
             libutfcpp-dev libxxhash-dev libgtest-dev libgmock-dev \
             libprotobuf-dev protobuf-compiler protobuf-compiler-grpc \
-            libgrpc++-dev libgrpc-dev
+            libgrpc++-dev libgrpc-dev \
+            libtirpc-dev libnsl-dev
+
+        echo "==> Stubbing pg_ctl (systemtests CMakeLists requires it; tests not run) ..."
+        printf '#!/bin/sh\n' > /usr/local/bin/pg_ctl && chmod +x /usr/local/bin/pg_ctl
 
         echo "==> Building tl-expected from source (no noble package) ..."
         git clone --depth 1 --branch v1.1.0 \

--- a/bareos-packages/build.sh
+++ b/bareos-packages/build.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BAREOS_BRANCH="${BAREOS_BRANCH:?BAREOS_BRANCH env var required (e.g. bareos-22)}"
+UBUNTU_CODENAME="${UBUNTU_CODENAME:?UBUNTU_CODENAME env var required (e.g. jammy)}"
+ARTIFACTS_DIR="/artifacts/${BAREOS_BRANCH}/${UBUNTU_CODENAME}"
+
+echo "==> Cloning ${BAREOS_BRANCH} ..."
+git clone --depth 1 --branch "${BAREOS_BRANCH}" \
+    https://github.com/bareos/bareos.git /src
+
+cd /src
+
+if [ ! -f debian/changelog ]; then
+    VERSION="${BAREOS_BRANCH#bareos-}.0.0~localsrc"
+    echo "==> Generating debian/changelog (${VERSION}) ..."
+    DEBEMAIL="builder@localhost" DEBFULLNAME="Local Builder" \
+        dch --create --empty \
+            --package bareos \
+            --newversion "${VERSION}" \
+            --distribution "${UBUNTU_CODENAME}" \
+            "Local build from source branch ${BAREOS_BRANCH}"
+fi
+
+echo "==> Installing build dependencies ..."
+apt-get update -qq
+
+case "${BAREOS_BRANCH}" in
+    bareos-23)
+        echo "==> Installing Qt5 Widgets for tray-monitor (v23) ..."
+        apt-get install -qq -y --no-install-recommends \
+            qtbase5-dev qttools5-dev qtbase5-dev-tools libqt5widgets5
+        ;;
+    bareos-24)
+        echo "==> Installing Qt5 + gRPC + CPM-satisfying system packages (v24) ..."
+        apt-get install -qq -y --no-install-recommends \
+            qtbase5-dev qttools5-dev qtbase5-dev-tools libqt5widgets5 \
+            libcli11-dev libfmt-dev libmsgsl-dev \
+            libutfcpp-dev libxxhash-dev libgtest-dev libgmock-dev \
+            libprotobuf-dev protobuf-compiler protobuf-compiler-grpc \
+            libgrpc++-dev libgrpc-dev
+
+        echo "==> Building tl-expected from source (no noble package) ..."
+        git clone --depth 1 --branch v1.1.0 \
+            https://github.com/TartanLlama/expected.git /tmp/tl-expected
+        cmake -S /tmp/tl-expected -B /tmp/tl-expected/build \
+            -DCMAKE_INSTALL_PREFIX=/usr -DEXPECTED_BUILD_TESTS=OFF
+        cmake --install /tmp/tl-expected/build
+        rm -rf /tmp/tl-expected
+        ;;
+esac
+
+mk-build-deps \
+    --install \
+    --remove \
+    --tool "apt-get -qq -y --no-install-recommends -o Debug::pkgProblemResolver=yes" \
+    debian/control
+rm -f /src/bareos-build-deps_*.deb
+
+echo "==> Building packages (nocheck nodoc) ..."
+DEB_BUILD_OPTIONS="nocheck nodoc parallel=$(nproc)" \
+    dpkg-buildpackage -us -uc -b
+
+echo "==> Collecting artifacts ..."
+mkdir -p "${ARTIFACTS_DIR}"
+find / -maxdepth 1 -name "bareos*.deb" -exec cp {} "${ARTIFACTS_DIR}/" \;
+
+echo "==> Done. Produced packages:"
+ls -lh "${ARTIFACTS_DIR}/"

--- a/bareos-packages/matrix.yml
+++ b/bareos-packages/matrix.yml
@@ -1,0 +1,18 @@
+# Build matrix: (bareos_branch, ubuntu_codename) tuples
+#
+# bareos-22 / jammy  — Bareos 22.x on Ubuntu 22.04 (upstream apt has none)
+# bareos-23 / jammy  — Bareos 23.x on Ubuntu 22.04 (upstream apt has none)
+# bareos-24 / noble  — Bareos 24.x on Ubuntu 24.04 (upstream only has 25.x)
+#
+# Bareos 25 is served by download.bareos.org/current/ and does not need
+# a source build. bareos-20 and bareos-21 have upstream versioned repos.
+#
+# Alpine is not listed here — no upstream APKBUILD exists; deferred.
+
+matrix:
+  - bareos_branch: bareos-22
+    ubuntu_codename: jammy
+  - bareos_branch: bareos-23
+    ubuntu_codename: jammy
+  - bareos_branch: bareos-24
+    ubuntu_codename: noble


### PR DESCRIPTION
download.bareos.org publishes versioned repos only for Bareos 20 and 21; the current/ repo serves only the latest (25.x) release. This adds a Docker-based build pipeline that compiles .deb packages from the upstream bareos/bareos release branches (bareos-22, bareos-23, bareos-24) using the Debian packaging tree shipped in the source repo.

- bareos-packages/Dockerfile.builder.{jammy,noble}: minimal Ubuntu build environments with devscripts/debhelper/cmake/equivs
- bareos-packages/build.sh: clones the target bareos branch, installs build-deps via mk-build-deps, runs dpkg-buildpackage with nocheck/nodoc, and collects .deb output under /artifacts/<branch>/<codename>/
- bareos-packages/matrix.yml: documents the three supported build tuples
- .github/workflows/build-bareos-packages.yml: CI job (90 min timeout, fail-fast disabled) that builds the matrix, uploads artifacts with 30-day retention, and publishes tarballs to a GitHub Release on pkg/* tags
- CLAUDE.md: updated version-support table, corrected active version list, added upstream availability reference and notes on when to use the builder