### PR TITLE
feat: add Bareos 25 Ubuntu images

### DIFF
--- a/.claude/skills/add-bareos-version/references/upstream-sources.md
+++ b/.claude/skills/add-bareos-version/references/upstream-sources.md
@@ -1,6 +1,6 @@
 # Bareos Upstream Source Table
 
-Last verified: 2026-04-18
+Last verified: 2026-06-01
 
 ## Ubuntu repos
 
@@ -11,7 +11,7 @@ Last verified: 2026-04-18
 | 22 | ubuntu:jammy (22.04) | `http://download.bareos.org/current/xUbuntu_22.04/Release.key` | `http://download.bareos.org/current/xUbuntu_22.04/` | ⚠ current/ installs latest Bareos (25.x as of 2026-04) |
 | 23 | — | — | — | ✗ no versioned repo; current/ does not pin to 23 |
 | 24 | ubuntu:noble (24.04) | `http://download.bareos.org/current/xUbuntu_24.04/Release.key` | `http://download.bareos.org/current/xUbuntu_24.04/` | ⚠ current/ installs latest Bareos (25.x as of 2026-04) |
-| 25 | — | — | — | ✗ no versioned repo; current/ does not pin to 25 |
+| 25 | ubuntu:noble (24.04) | `http://download.bareos.org/current/xUbuntu_24.04/Release.key` | `http://download.bareos.org/current/xUbuntu_24.04/` | ⚠ current/ installs latest Bareos (25.x as of 2026-06); 25-ubuntu images built from this |
 
 **Note**: For v22+, `current/` always tracks the latest Bareos release. The directory name reflects Ubuntu version, not Bareos version.
 
@@ -59,10 +59,11 @@ curl -sL "https://pypi.org/simple/bareos-restapi/" | grep -Eo 'bareos.restapi-[0
 | director-pgsql | 22-ubuntu | ✓ | Ubuntu 22.04 + current/ |
 | director-pgsql | 24-alpine | ✗ | No Alpine package for Bareos 24 |
 | director-pgsql | 23-alpine/ubuntu | ✗ | No upstream source |
-| director-pgsql | 25-alpine/ubuntu | ✗ | No upstream source |
-| storage | same as director-pgsql | same | same |
-| client | same as director-pgsql | same | same |
-| webui | same as director-pgsql | same | same |
+| director-pgsql | 25-ubuntu | ✓ | Ubuntu 24.04 + current/ |
+| director-pgsql | 25-alpine | ✗ | No Alpine package for Bareos 25 |
+| storage | 25-ubuntu | ✓ | Ubuntu 24.04 + current/ |
+| client | 25-ubuntu | ✓ | Ubuntu 24.04 + current/ |
+| webui | 25-ubuntu | ✓ | Ubuntu 24.04 + current/ |
 | api | 20-alpine | ✗ | bareos-restapi<21 not on PyPI |
 | api | 23-alpine | ✗ | No upstream source |
 | api | 25-alpine | ✗ | No upstream source |

--- a/.github/actions/prepare-bareos-app/entrypoint.sh
+++ b/.github/actions/prepare-bareos-app/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 BUILDX_VER='v0.5.1'
-latest_ubuntu='24'
+latest_ubuntu='25'
 latest_alpine='22'
 latest_api='21'
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ The CI uses reusable composite actions in `.github/actions/` (prepare, build, pu
 ## Version Support
 
 - Alpine images support `linux/amd64` and `linux/arm64/v8`
-- Current active versions: 22 (Ubuntu and Alpine), 24 (Ubuntu)
+- Current active versions: 22 (Ubuntu and Alpine), 24 (Ubuntu), 25 (Ubuntu)
 - MySQL backend was dropped in Bareos 21+; `director-mysql/` only goes up to version 20
 
 ### Upstream package availability
@@ -119,7 +119,7 @@ The CI uses reusable composite actions in `.github/actions/` (prepare, build, pu
 | 22             | `current/` (serves 25.x today) | Alpine 3.18       |
 | 23             | not published upstream          | not published     |
 | 24             | not published upstream          | not published     |
-| 25             | `current/` (latest)            | not published     |
+| 25             | `current/xUbuntu_24.04/`        | not published     |
 
 Use `bareos-packages/` to build `.deb` packages from source for versions 22–24.
 Once packages are published as GitHub Releases, use the `.claude/skills/add-bareos-version`

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Weekly image builds run from GitHub Actions. Alpine images are built for
 
 | backend | tags |
 |:--|:--|
-| PostgreSQL | `24-ubuntu-pgsql`, `24-ubuntu`, `24`, `ubuntu` |
+| PostgreSQL | `25-ubuntu-pgsql`, `25-ubuntu`, `25`, `ubuntu` |
+| PostgreSQL | `24-ubuntu-pgsql`, `24-ubuntu`, `24` |
 | PostgreSQL | `23-ubuntu-pgsql`, `23-ubuntu`, `23` |
 | PostgreSQL | `22-ubuntu-pgsql`, `22-ubuntu`, `22` |
 | PostgreSQL | `22-alpine-pgsql`, `22-alpine`, `alpine`, `latest` |
@@ -41,7 +42,8 @@ Weekly image builds run from GitHub Actions. Alpine images are built for
 
 | base | tags |
 |:--|:--|
-| Ubuntu 24.04 | `24-ubuntu`, `24`, `ubuntu` |
+| Ubuntu 24.04 | `25-ubuntu`, `25`, `ubuntu` |
+| Ubuntu 24.04 | `24-ubuntu`, `24` |
 | Ubuntu 22.04 | `23-ubuntu`, `23`, `22-ubuntu`, `22` |
 | Alpine 3.18 | `22-alpine`, `alpine`, `latest` |
 | Ubuntu 20.04 | `21-ubuntu`, `21`, `20-ubuntu`, `20` |
@@ -61,6 +63,7 @@ PyPI for those versions.
 
 | Bareos version | Ubuntu image | Alpine image | Notes |
 |:--|:--|:--|:--|
+| 25 | `25-ubuntu` on Ubuntu 24.04 | not available | Installed from `download.bareos.org/current/` |
 | 24 | `24-ubuntu` on Ubuntu 24.04 | not available | Installed from GitHub package release |
 | 23 | `23-ubuntu` on Ubuntu 22.04 | not available | Installed from GitHub package release |
 | 22 | `22-ubuntu` on Ubuntu 22.04 | `22-alpine` on Alpine 3.18 | Ubuntu uses GitHub package release |

--- a/client/25-ubuntu/Dockerfile
+++ b/client/25-ubuntu/Dockerfile
@@ -1,0 +1,51 @@
+# Dockerfile Bareos client/file daemon
+FROM ubuntu:noble
+
+LABEL maintainer="barcus@tou.nu"
+
+ARG BUILD_DATE
+ARG NAME
+ARG VCS_REF
+ARG VERSION
+
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$NAME \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url="https://github.com/barcus/bareos" \
+      org.label-schema.version=$VERSION
+
+ENV BAREOS_DAEMON_USER=bareos
+ENV BAREOS_DAEMON_GROUP=bareos
+ENV DEBIAN_FRONTEND=noninteractive
+
+ARG BAREOS_KEY=http://download.bareos.org/current/xUbuntu_24.04/Release.key
+ARG BAREOS_REPO=http://download.bareos.org/current/xUbuntu_24.04/
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update -qq \
+ && apt-get install -qq -y --no-install-recommends curl gnupg ca-certificates \
+ && curl -fsSL "${BAREOS_KEY}" | gpg --dearmor -o /usr/share/keyrings/bareos.gpg \
+ && echo "deb [signed-by=/usr/share/keyrings/bareos.gpg] ${BAREOS_REPO} /" \
+      > /etc/apt/sources.list.d/bareos.list \
+ && apt-get update -qq \
+ && apt-get install -qq -y --no-install-recommends \
+    gosu tzdata default-mysql-client postgresql-client \
+    bareos-bconsole \
+    bareos-common \
+    bareos-client \
+    bareos-filedaemon \
+    bareos-tools \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/bareos.list
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod a+x /docker-entrypoint.sh
+
+RUN tar czf /bareos-fd.tgz /etc/bareos/bareos-fd.d
+
+EXPOSE 9102
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["/usr/sbin/bareos-fd", "-f"]

--- a/client/25-ubuntu/docker-entrypoint.sh
+++ b/client/25-ubuntu/docker-entrypoint.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#set -x
+
+bareos_fd_config="/etc/bareos/bareos-fd.d/director/bareos-dir.conf"
+
+if [ "${FORCE_ROOT}" = true ]; then
+  BAREOS_DAEMON_USER='root'
+  BAREOS_DAEMON_GROUP='root'
+fi
+
+if [ $(id -u) = '0' ]; then
+  [ -n "${PUID}" ] && usermod -u ${PUID} ${BAREOS_DAEMON_USER}
+  [ -n "${PGID}" ] && groupmod -g ${PGID} ${BAREOS_DAEMON_GROUP}
+
+  if [ ! -f /etc/bareos/bareos-config.control ]; then
+    tar xzf /bareos-fd.tgz --backup=simple --suffix=.before-control
+
+    # Force client/file daemon password
+    sed -i 's#Password = .*#Password = '\""${BAREOS_FD_PASSWORD}"\"'#' $bareos_fd_config
+
+    # Control file
+    touch /etc/bareos/bareos-config.control
+  fi
+
+  # Fix permissions
+  find /etc/bareos ! -user ${BAREOS_DAEMON_USER} -exec chown ${BAREOS_DAEMON_USER}:${BAREOS_DAEMON_GROUP} {} \;
+  chown -R ${BAREOS_DAEMON_USER}:${BAREOS_DAEMON_GROUP} /var/lib/bareos /var/log/bareos
+
+  # Gosu
+  [ "${BAREOS_DAEMON_USER}" != 'root' ] && exec gosu "${BAREOS_DAEMON_USER}" "$BASH_SOURCE" "$@"
+fi
+
+exec "$@"

--- a/director-pgsql/25-ubuntu/Dockerfile
+++ b/director-pgsql/25-ubuntu/Dockerfile
@@ -1,0 +1,67 @@
+# Bareos director Dockerfile
+FROM ubuntu:noble
+
+LABEL maintainer="barcus@tou.nu"
+
+ARG BUILD_DATE
+ARG NAME
+ARG VCS_REF
+ARG VERSION
+
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$NAME \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url="https://github.com/barcus/bareos" \
+      org.label-schema.version=$VERSION
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV BAREOS_DPKG_CONF="bareos-database-common bareos-database-common"
+
+ARG BAREOS_KEY=http://download.bareos.org/current/xUbuntu_24.04/Release.key
+ARG BAREOS_REPO=http://download.bareos.org/current/xUbuntu_24.04/
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update -qq \
+ && apt-get install -qq -y --no-install-recommends curl gnupg ca-certificates \
+ && curl -fsSL "${BAREOS_KEY}" | gpg --dearmor -o /usr/share/keyrings/bareos.gpg \
+ && echo "deb [signed-by=/usr/share/keyrings/bareos.gpg] ${BAREOS_REPO} /" \
+      > /etc/apt/sources.list.d/bareos.list \
+ && echo "${BAREOS_DPKG_CONF}/dbconfig-install boolean false" \
+    | debconf-set-selections \
+ && echo "${BAREOS_DPKG_CONF}/install-error select ignore" \
+    | debconf-set-selections \
+ && echo "${BAREOS_DPKG_CONF}/database-type select pgsql" \
+    | debconf-set-selections \
+ && echo "${BAREOS_DPKG_CONF}/missing-db-package-error select ignore" \
+    | debconf-set-selections \
+ && echo 'postfix postfix/main_mailer_type select No configuration' \
+    | debconf-set-selections \
+ && apt-get update -qq \
+ && apt-get install -qq -y --no-install-recommends \
+    curl tzdata postgresql-client \
+    bareos-bconsole \
+    bareos-common \
+    bareos-director \
+    bareos-database-common \
+    bareos-database-postgresql \
+    bareos-database-tools \
+    bareos-tools \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/bareos.list
+
+RUN tar czf /bareos-dir.tgz /etc/bareos
+
+COPY webhook-notify /usr/local/bin/webhook-notify
+RUN chmod u+x /usr/local/bin/webhook-notify
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod u+x /docker-entrypoint.sh
+
+EXPOSE 9101
+
+VOLUME /etc/bareos
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["/usr/sbin/bareos-dir", "-u", "bareos", "-f"]

--- a/director-pgsql/25-ubuntu/docker-entrypoint.sh
+++ b/director-pgsql/25-ubuntu/docker-entrypoint.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+
+github_bareos='raw.githubusercontent.com/bareos/bareos'
+webui_admin_conf='Release/25.0.3/webui/install/bareos/bareos-dir.d/profile/webui-admin.conf'
+admin_conf='Release/25.0.3/webui/install/bareos/bareos-dir.d/console/admin.conf.example'
+
+if [ ! -f /etc/bareos/bareos-config.control ]; then
+  tar xzf /bareos-dir.tgz --backup=simple --suffix=.before-control
+
+  # Download default admin profile config
+  if [ ! -f /etc/bareos/bareos-dir.d/profile/webui-admin.conf ]; then
+    curl --silent --insecure "https://${github_bareos}/${webui_admin_conf}" \
+      --output /etc/bareos/bareos-dir.d/profile/webui-admin.conf
+  fi
+
+  # Download default webUI admin config
+  if [ ! -f /etc/bareos/bareos-dir.d/console/admin.conf ]; then
+    curl --silent --insecure "https://${github_bareos}/${admin_conf}" \
+      --output /etc/bareos/bareos-dir.d/console/admin.conf
+  fi
+
+  # Update bareos-director configs
+  # Director / mycatalog & mail report
+  sed -i 's#dbuser = "bareos"#dbuser = '\"${DB_USER}\"'#' \
+    /etc/bareos/bareos-dir.d/catalog/MyCatalog.conf
+  sed -i 's#dbpassword = ""#dbpassword = '\"${DB_PASSWORD}\"'#' \
+    /etc/bareos/bareos-dir.d/catalog/MyCatalog.conf
+  sed -i 's#dbname = "bareos"#dbname = '\"${DB_NAME}\"'\n  dbaddress = '\"${DB_HOST}\"'\n  dbport = '\"${DB_PORT}\"'#' \
+    /etc/bareos/bareos-dir.d/catalog/MyCatalog.conf
+  [ -n "${SENDER_MAIL}" ] && sed -i "s#<%r#<${SENDER_MAIL}#g" \
+    /etc/bareos/bareos-dir.d/messages/Daemon.conf
+  sed -i "s#/usr/bin/bsmtp -h localhost#/usr/bin/bsmtp -h ${SMTP_HOST}#" \
+    /etc/bareos/bareos-dir.d/messages/Daemon.conf
+  sed -i "s#mail = root#mail = ${ADMIN_MAIL}#" \
+    /etc/bareos/bareos-dir.d/messages/Daemon.conf
+  [ -n "${SENDER_MAIL}" ] && sed -i "s#<%r#<${SENDER_MAIL}#g" \
+    /etc/bareos/bareos-dir.d/messages/Standard.conf
+  sed -i "s#/usr/bin/bsmtp -h localhost#/usr/bin/bsmtp -h ${SMTP_HOST}#" \
+    /etc/bareos/bareos-dir.d/messages/Standard.conf
+  sed -i "s#mail = root#mail = ${ADMIN_MAIL}#" \
+    /etc/bareos/bareos-dir.d/messages/Standard.conf
+
+  # Setup webhook
+  if [ "${WEBHOOK_NOTIFICATION}" = true ]; then
+    sed -i "s#/usr/bin/bsmtp -h.*#/usr/local/bin/webhook-notify %t %e %c %l %n\"#" \
+      /etc/bareos/bareos-dir.d/messages/Daemon.conf
+    sed -i "s#/usr/bin/bsmtp -h.*#/usr/local/bin/webhook-notify %t %e %c %l %n\"#" \
+      /etc/bareos/bareos-dir.d/messages/Standard.conf
+  fi
+
+  # storage daemon
+  sed -i 's#Address = .*#Address = '\""${BAREOS_SD_HOST}"\"'#' \
+    /etc/bareos/bareos-dir.d/storage/File.conf
+  sed -i 's#Password = .*#Password = '\""${BAREOS_SD_PASSWORD}"\"'#' \
+    /etc/bareos/bareos-dir.d/storage/File.conf
+
+  # client/file daemon
+  sed -i 's#Address = .*#Address = '\""${BAREOS_FD_HOST}"\"'#' \
+    /etc/bareos/bareos-dir.d/client/bareos-fd.conf
+  sed -i 's#Password = .*#Password = '\""${BAREOS_FD_PASSWORD}"\"'#' \
+    /etc/bareos/bareos-dir.d/client/bareos-fd.conf
+
+  # webUI
+  sed -i 's#Password = .*#Password = '\""${BAREOS_WEBUI_PASSWORD}"\"'#' \
+    /etc/bareos/bareos-dir.d/console/admin.conf
+  sed -i "s#}#  TlsEnable = false\n}#" \
+    /etc/bareos/bareos-dir.d/console/admin.conf
+
+  # MyCatalog Backup
+  sed -i "s#/var/lib/bareos/bareos.sql#/var/lib/bareos-director/bareos.sql#" \
+    /etc/bareos/bareos-dir.d/fileset/Catalog.conf
+
+  # Control file
+  touch /etc/bareos/bareos-config.control
+fi
+
+if [[ -z ${CI_TEST} ]] ; then
+  # Waiting Postgresql is up
+  sqlup=1
+  while [ "$sqlup" -ne 0 ] ; do
+    echo "Waiting for postgresql..."
+    pg_isready --host="${DB_HOST}" --port="${DB_PORT}" --user="${DB_ADMIN_USER}"
+    if [ $? -ne 0 ] ; then
+      sqlup=1
+      sleep 5
+    else
+      sqlup=0
+      echo "...postgresql is alive"
+    fi
+  done
+fi
+
+export PGUSER=${DB_ADMIN_USER}
+export PGHOST=${DB_HOST}
+export PGPASSWORD=${DB_ADMIN_PASSWORD}
+[[ -z "${DB_INIT}" ]] && DB_INIT='false'
+[[ -z "${DB_UPDATE}" ]] && DB_UPDATE='false'
+
+if [ ! -f /etc/bareos/bareos-db.control ] && [ "${DB_INIT}" == 'true' ] ; then
+  # Init Postgresql DB
+  echo "Bareos DB init"
+  echo "Bareos DB init: Create user ${DB_USER}"
+  psql -c "create user ${DB_USER} with createdb createrole login;"
+  echo "Bareos DB init: Set user password"
+  psql -c "alter user ${DB_USER} password '${DB_PASSWORD}';"
+  /usr/lib/bareos/scripts/create_bareos_database 2>/dev/null
+  /usr/lib/bareos/scripts/make_bareos_tables 2>/dev/null
+  /usr/lib/bareos/scripts/grant_bareos_privileges 2>/dev/null
+
+  # Control file
+  touch /etc/bareos/bareos-db.control
+fi
+
+if [ "${DB_UPDATE}" == 'true' ] ; then
+  # Try Postgres upgrade
+  echo "Bareoos DB update"
+  echo "Bareoos DB update: Update tables"
+  /usr/lib/bareos/scripts/update_bareos_tables 2>/dev/null
+  echo "Bareoos DB update: Grant privileges"
+  /usr/lib/bareos/scripts/grant_bareos_privileges 2>/dev/null
+fi
+
+# Fix permissions
+find /etc/bareos ! -user bareos -exec chown bareos {} \;
+chown -R bareos:bareos /var/lib/bareos
+
+# Run Dockerfile CMD
+exec "$@"

--- a/director-pgsql/25-ubuntu/webhook-notify
+++ b/director-pgsql/25-ubuntu/webhook-notify
@@ -1,0 +1,41 @@
+#!/usr/bin/env sh
+
+job_type=$1
+job_status=$2
+job_client=$3
+job_level=$4
+job_name=$5
+msg_icon="❌"
+
+if [ "$job_status" = "OK" ] ;then
+  msg_icon="✅"
+fi
+
+msg_txt="$msg_icon Bareos: $job_type $job_status of $job_client \
+$job_level (${job_name})"
+
+load_json()
+{
+  if [ "${WEBHOOK_TYPE}" = "slack" ] ; then
+    cat <<EOF
+{
+  "text": "$msg_txt"
+}
+EOF
+ fi
+
+ if [ "${WEBHOOK_TYPE}" = "telegram" ] ; then
+    cat <<EOF
+{
+  "chat_id": "${WEBHOOK_CHAT_ID}",
+  "text": "$msg_txt",
+  "disable_notification": false
+}
+EOF
+ fi
+}
+
+/usr/bin/curl -s -k -X POST \
+    -H 'Content-Type: application/json' \
+    -d "$(load_json)" \
+    ${WEBHOOK_URL}

--- a/storage/25-ubuntu/Dockerfile
+++ b/storage/25-ubuntu/Dockerfile
@@ -1,0 +1,51 @@
+# Dockerfile Bareos storage daemon
+FROM ubuntu:noble
+
+LABEL maintainer="barcus@tou.nu"
+
+ARG BUILD_DATE
+ARG NAME
+ARG VCS_REF
+ARG VERSION
+
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$NAME \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url="https://github.com/barcus/bareos" \
+      org.label-schema.version=$VERSION
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+ARG BAREOS_KEY=http://download.bareos.org/current/xUbuntu_24.04/Release.key
+ARG BAREOS_REPO=http://download.bareos.org/current/xUbuntu_24.04/
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update -qq \
+ && apt-get install -qq -y --no-install-recommends curl gnupg ca-certificates \
+ && curl -fsSL "${BAREOS_KEY}" | gpg --dearmor -o /usr/share/keyrings/bareos.gpg \
+ && echo "deb [signed-by=/usr/share/keyrings/bareos.gpg] ${BAREOS_REPO} /" \
+      > /etc/apt/sources.list.d/bareos.list \
+ && apt-get update -qq \
+ && apt-get install -qq -y --no-install-recommends \
+    tzdata mtx scsitools sg3-utils mt-st \
+    bareos-common \
+    bareos-storage \
+    bareos-storage-tape \
+    bareos-tools \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/bareos.list
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod u+x /docker-entrypoint.sh
+
+RUN tar czf /bareos-sd.tgz /etc/bareos/bareos-sd.d
+
+EXPOSE 9103
+
+VOLUME /etc/bareos
+VOLUME /var/lib/bareos/storage
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["/usr/sbin/bareos-sd", "-u", "bareos", "-f"]

--- a/storage/25-ubuntu/docker-entrypoint.sh
+++ b/storage/25-ubuntu/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+bareos_sd_config="/etc/bareos/bareos-sd.d/director/bareos-dir.conf"
+
+if [ ! -f /etc/bareos/bareos-config.control ]; then
+  tar xfz /bareos-sd.tgz --backup=simple --suffix=.before-control
+
+  # Update bareos-storage configs
+  sed -i 's#Password = .*#Password = '\""${BAREOS_SD_PASSWORD}"\"'#' $bareos_sd_config
+
+  # Control file
+  touch /etc/bareos/bareos-config.control
+fi
+
+# Fix permissions
+find /var/lib/bareos ! -user bareos -exec chown bareos {} \;
+find /etc/bareos/bareos-sd.d ! -user bareos -exec chown bareos {} \;
+find /dev -regex "/dev/[n]?st[0-9]+" ! -user bareos -exec chown bareos {} \;
+find /dev -regex "/dev/tape/.*" ! -user bareos -exec chown bareos {} \;
+
+# Run Dockerfile CMD
+exec "$@"

--- a/webui/25-ubuntu/Dockerfile
+++ b/webui/25-ubuntu/Dockerfile
@@ -1,0 +1,47 @@
+# Bareos Web-ui Dockerfile
+FROM ubuntu:noble
+
+LABEL maintainer="barcus@tou.nu"
+
+ARG BUILD_DATE
+ARG NAME
+ARG VCS_REF
+ARG VERSION
+
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$NAME \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url="https://github.com/barcus/bareos" \
+      org.label-schema.version=$VERSION
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+ARG BAREOS_KEY=http://download.bareos.org/current/xUbuntu_24.04/Release.key
+ARG BAREOS_REPO=http://download.bareos.org/current/xUbuntu_24.04/
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update -qq \
+ && apt-get install -qq -y --no-install-recommends curl gnupg ca-certificates \
+ && curl -fsSL "${BAREOS_KEY}" | gpg --dearmor -o /usr/share/keyrings/bareos.gpg \
+ && echo "deb [signed-by=/usr/share/keyrings/bareos.gpg] ${BAREOS_REPO} /" \
+      > /etc/apt/sources.list.d/bareos.list \
+ && apt-get update -qq \
+ && apt-get install -qq -y --no-install-recommends \
+    tzdata \
+    bareos-webui \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/bareos.list
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod u+x /docker-entrypoint.sh
+
+RUN tar czf /bareos-webui.tgz /etc/bareos-webui
+
+EXPOSE 80
+
+VOLUME /etc/bareos-webui
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["/usr/sbin/apache2ctl", "-D", "FOREGROUND"]

--- a/webui/25-ubuntu/docker-entrypoint.sh
+++ b/webui/25-ubuntu/docker-entrypoint.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+if [ ! -f /etc/bareos-webui/bareos-config.control ];then
+  tar xzf /bareos-webui.tgz --backup=simple --suffix=.before-control
+
+  # Update bareos-webui config
+  sed -i 's#diraddress.*#diraddress = '\""${BAREOS_DIR_HOST}"\"'#' \
+    /etc/bareos-webui/directors.ini
+
+  # Control file
+  touch /etc/bareos-webui/bareos-config.control
+fi
+
+apache_conf="/etc/apache2/sites-available/000-default.conf"
+
+# Set document root
+sed -i "s#/var/www/html#/usr/share/bareos-webui/public#g" $apache_conf
+
+# Enable Apache server stats
+if [ "${SERVER_STATS}" == "yes" ]; then
+  sed -i 's!#ServerName.*!Alias /server-status /var/www/dummy!' $apache_conf
+fi
+
+# Run Dockerfile CMD
+exec "$@"


### PR DESCRIPTION
## Summary

- Add `25-ubuntu` directories for `director-pgsql`, `storage`, `client`, and `webui`
- Dockerfiles install from `download.bareos.org/current/xUbuntu_24.04/` using the gpg-keyring apt style (same approach as v22-ubuntu from that repo, not the GitHub package tarball used by v22–24)
- Entrypoint scripts copied verbatim from `24-ubuntu`; director entrypoint updated to fetch webui config templates from `Release/25.0.3`
- Bump `latest_ubuntu` from `24` → `25` in `prepare-bareos-app/entrypoint.sh` so the floating `ubuntu`/`latest` tags move to Bareos 25
- Update README, CLAUDE.md, and upstream-sources reference with 25 rows

## Notes

- `current/` currently serves `25.0.4~pre142` (a pre-release); images will report that version, not a clean `25.0.3`
- Once Bareos 26 ships, the weekly scheduled rebuild will roll these images to 26. Follow-up: pin 25 via a `bareos-packages` source build from `Release/25.0.x`, mirroring how 24 is pinned today
- `director-mysql` and `api` skipped (MySQL backend dropped at v21; `bareos-restapi` PyPI only has v21)
- Alpine skipped (no Alpine packages for Bareos 23+)

## Test plan

- [x] `docker build --platform linux/amd64` passes for all four components
- [x] `bareos-dir --version`, `bareos-sd --version`, `bareos-fd --version` all report `25.0.4~pre142`
- [ ] CI: `ci-director.yml`, `ci-storage.yml`, `ci-client.yml`, `ci-webui.yml` green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)