### PR TITLE
Added notes about dbdriver deprecation in Bareos 23

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ Bareos removed the MySQL catalog backend in version 21. Use `director-mysql/*`
 only for Bareos 20 or older and migrate existing MySQL catalogs to PostgreSQL
 before upgrading past Bareos 20.
 
+Bareos 23 removed the `dbdriver` directive from the catalog resource. If you
+are upgrading from Bareos 22 or older, remove any `dbdriver = "postgresql"`
+line from `/etc/bareos/bareos-dir.d/catalog/MyCatalog.conf` before starting
+the Director. Leaving it in place causes a fatal config error:
+
+```
+bareos-dir: CONFIG ERROR at lib/parse_conf_state_machine.cc:161
+Config error: Keyword "dbdriver" not permitted in this resource.
+```
+
 ## Package Releases
 
 `download.bareos.org/current/` tracks the latest Bareos release and does not


### PR DESCRIPTION
In Bareos 23 dbdriver it has been deprecated, in case it's still present it will cause Bareos Director to fail to start with the following error:
```
In bareos I'm getting Waiting for postgresql...
bareos-db:5432 - accepting connections
...postgresql is alive
Bareoos DB update
Bareoos DB update: Update tables
Bareoos DB update: Grant privileges
GRANT
GRANT
GRANT
GRANT
bareos-dir: CONFIG ERROR at lib/parse_conf_state_machine.cc:161
Config error: Keyword "dbdriver" not permitted in this resource.
Perhaps you left the trailing brace off of the previous resource.
            : line 4, col 11 of file /etc/bareos/bareos-dir.d/catalog/MyCatalog.conf
  dbdriver = "postgresql"
```